### PR TITLE
feat: Add async client support for Cloud Tasks and Cloud Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ creating Cloud Scheduler jobs dynamically from request handlers. Since it can't 
 time like the sync version, await it from a lifespan (or a handler):
 
 ```python
+from contextlib import asynccontextmanager
+
 from fastapi_gcp_tasks import AsyncScheduledRouteBuilder
 
 async_scheduled_router = APIRouter(route_class=AsyncScheduledRouteBuilder(...))
@@ -178,6 +180,8 @@ Things to know about the async builders:
   the first `.delay()`:
 
   ```python
+  from contextlib import asynccontextmanager
+
   from fastapi_gcp_tasks.utils import ensure_queue_async
 
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ pip install fastapi-gcp-tasks
 - Familiar and simple public API
   - `.delay` method that takes same arguments as the task.
   - `.scheduler` method to create recurring job.
+  - Async variants (`AsyncDelayedRouteBuilder` / `AsyncScheduledRouteBuilder`) so `await .delay()` never blocks the event loop.
 - Tasks are regular FastAPI endpoints on plain old HTTP.
   - `Depends` just works!
   - All middlewares, telemetry, auth, debugging etc solutions for FastAPI work as is.
@@ -116,6 +117,78 @@ app.include_router(scheduled_router)
 home_cook.scheduler(name="test-home-cook-at-7AM-IST", schedule="0 7 * * *", time_zone="Asia/Kolkata").schedule(
   recipe=Recipe(ingredients=["Milk", "Cereal"]))
 ```
+
+### Async usage
+
+`DelayedRouteBuilder`'s `.delay()` makes a blocking gRPC call. Called from an async endpoint, it stalls the
+event loop until Cloud Tasks responds. `AsyncDelayedRouteBuilder` uses the native
+`CloudTasksAsyncClient` instead, so triggering a task is a proper coroutine:
+
+```python
+from fastapi_gcp_tasks import AsyncDelayedRouteBuilder
+
+async_delayed_router = APIRouter(route_class=AsyncDelayedRouteBuilder(...))
+
+
+@async_delayed_router.post("/{restaurant}/make_dinner")
+async def make_dinner(restaurant: str, recipe: Recipe):
+    ...
+
+
+app.include_router(async_delayed_router)
+
+# In an async context (endpoint, lifespan, etc):
+await make_dinner.delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))
+await make_dinner.options(countdown=1800).delay(...)
+```
+
+Similarly, `AsyncScheduledRouteBuilder` provides awaitable `.schedule()` and `.delete()` — useful when
+creating Cloud Scheduler jobs dynamically from request handlers. Since it can't run at module import
+time like the sync version, await it from a lifespan (or a handler):
+
+```python
+from fastapi_gcp_tasks import AsyncScheduledRouteBuilder
+
+async_scheduled_router = APIRouter(route_class=AsyncScheduledRouteBuilder(...))
+
+
+@async_scheduled_router.post("/home_cook")
+async def home_cook(recipe: Recipe):
+    ...
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await home_cook.scheduler(name="home-cook-7AM-IST", schedule="0 7 * * *", time_zone="Asia/Kolkata").schedule(
+        recipe=Recipe(ingredients=["Milk", "Cereal"])
+    )
+    yield
+```
+
+Things to know about the async builders:
+
+- **The client is created lazily.** grpc.aio clients bind to the event loop that is running when they are
+  constructed, so the builder resolves its client on the first awaited call, inside your app's loop. `client`
+  accepts a client instance, a zero-argument factory returning one, or `None` (default credentials). If your
+  client needs custom construction — like the local emulator — pass a factory:
+  `client=lambda: async_emulator_client()`.
+- **The queue is not auto-created by default.** Unlike `DelayedRouteBuilder`, `auto_create_queue` defaults to
+  `False` so no unexpected RPC runs inside a request handler. Either ensure the queue from your lifespan with
+  the `ensure_queue_async` util (recommended), or opt in with `auto_create_queue=True` to ensure it lazily on
+  the first `.delay()`:
+
+  ```python
+  from fastapi_gcp_tasks.utils import ensure_queue_async
+
+
+  @asynccontextmanager
+  async def lifespan(app: FastAPI):
+      await ensure_queue_async(client=my_async_client, path=MY_QUEUE_PATH)
+      yield
+  ```
+
+- **Hooks are unchanged.** The same (synchronous) `pre_create_hook`s work with both builders — they are pure
+  in-memory mutations of the request proto and run inline on the event loop, so they must not block.
 
 ## Concept
 
@@ -320,6 +393,15 @@ Example:
 simple_task.options(countdown=120).delay()
 ```
 
+### AsyncDelayedRouteBuilder
+
+Same options as `DelayedRouteBuilder`, with two differences:
+
+- `client` - A `CloudTasksAsyncClient`, a zero-argument factory returning one, or `None`. Resolved lazily on
+  the first awaited `.delay()` because grpc.aio clients bind to the running event loop.
+- `auto_create_queue` - Defaults to `False` (the sync builder defaults to `True`). When `True`, the queue is
+  ensured lazily on the first `.delay()`. Prefer calling `ensure_queue_async` from your lifespan instead.
+
 ### ScheduledRouteBuilder
 
 Usage:
@@ -335,6 +417,12 @@ def simple_scheduled_task():
 
 simple_scheduled_task.scheduler(name="simple_scheduled_task", schedule="* * * * *").schedule()
 ```
+
+### AsyncScheduledRouteBuilder
+
+Same options as `ScheduledRouteBuilder`, except `client` accepts a `CloudSchedulerAsyncClient`, a
+zero-argument factory returning one, or `None` (resolved lazily, as above). `.schedule()` and `.delete()`
+are coroutines — await them from a lifespan or a request handler.
 
 
 ## Hooks

--- a/examples/full/main.py
+++ b/examples/full/main.py
@@ -8,7 +8,7 @@ from google.api_core.exceptions import AlreadyExists
 # Imports from this repository
 from examples.full.serializer import Payload
 from examples.full.settings import IS_LOCAL
-from examples.full.tasks import fail_twice, hello
+from examples.full.tasks import fail_twice, hello, hello_async
 
 app = FastAPI()
 
@@ -19,6 +19,18 @@ task_id = str(uuid4())
 async def basic():
     hello.delay(p=Payload(message="Basic task"))
     return {"message": "Basic hello task scheduled"}
+
+
+@app.get("/async_basic")
+async def async_basic():
+    await hello_async.delay(p=Payload(message="Async basic task"))
+    return {"message": "Async basic hello task scheduled"}
+
+
+@app.get("/async_with_countdown")
+async def async_with_countdown():
+    await hello_async.options(countdown=5).delay(p=Payload(message="Async countdown task"))
+    return {"message": "Async countdown hello task scheduled"}
 
 
 @app.get("/with_countdown")

--- a/examples/full/tasks.py
+++ b/examples/full/tasks.py
@@ -17,7 +17,7 @@ from examples.full.settings import (
     TASK_OIDC_TOKEN,
     TASK_QUEUE_PATH,
 )
-from fastapi_gcp_tasks import DelayedRouteBuilder
+from fastapi_gcp_tasks import AsyncDelayedRouteBuilder, DelayedRouteBuilder
 from fastapi_gcp_tasks.dependencies import max_retries
 from fastapi_gcp_tasks.hooks import (
     chained_hook,
@@ -27,7 +27,7 @@ from fastapi_gcp_tasks.hooks import (
     oidc_scheduled_hook,
 )
 from fastapi_gcp_tasks.scheduled_route import ScheduledRouteBuilder
-from fastapi_gcp_tasks.utils import emulator_client
+from fastapi_gcp_tasks.utils import async_emulator_client, emulator_client
 
 app = FastAPI()
 
@@ -77,6 +77,28 @@ ScheduledRoute = ScheduledRouteBuilder(
     ),
 )
 
+
+# The async client binds to the running event loop, so pass a factory that is
+# resolved lazily on the first awaited .delay() instead of a client instance.
+def _local_async_delayed_client():
+    return async_emulator_client(host=CLOUD_TASKS_EMULATOR_URL)
+
+
+AsyncDelayedRoute = AsyncDelayedRouteBuilder(
+    client=_local_async_delayed_client if IS_LOCAL else None,
+    base_url=TASK_LISTENER_BASE_URL,
+    queue_path=TASK_QUEUE_PATH,
+    auto_create_queue=True,
+    pre_create_hook=chained_hook(
+        # Add service account for cloud run
+        oidc_delayed_hook(
+            token=TASK_OIDC_TOKEN,
+        ),
+        # Wait for half an hour
+        deadline_delayed_hook(duration=duration_pb2.Duration(seconds=1800)),
+    ),
+)
+
 delayed_router = APIRouter(route_class=DelayedRoute, prefix="/delayed")
 
 
@@ -89,6 +111,15 @@ async def hello(p: Payload = Payload(message="Default")):
 @delayed_router.post("/fail_twice", dependencies=[Depends(max_retries(2))])
 async def fail_twice():
     raise Exception("nooo")
+
+
+async_delayed_router = APIRouter(route_class=AsyncDelayedRoute, prefix="/async_delayed")
+
+
+@async_delayed_router.post("/hello")
+async def hello_async(p: Payload = Payload(message="Default")):
+    message = f"Async hello task ran with payload: {p.message}"
+    logger.warning(message)
 
 
 scheduled_router = APIRouter(route_class=ScheduledRoute, prefix="/scheduled")
@@ -110,4 +141,5 @@ if not IS_LOCAL:
     ).schedule(p=Payload(message="Scheduled"))
 
 app.include_router(delayed_router)
+app.include_router(async_delayed_router)
 app.include_router(scheduled_router)

--- a/fastapi_gcp_tasks/__init__.py
+++ b/fastapi_gcp_tasks/__init__.py
@@ -1,5 +1,12 @@
 # Imports from this repository
+from fastapi_gcp_tasks.async_delayed_route import AsyncDelayedRouteBuilder
+from fastapi_gcp_tasks.async_scheduled_route import AsyncScheduledRouteBuilder
 from fastapi_gcp_tasks.delayed_route import DelayedRouteBuilder
 from fastapi_gcp_tasks.scheduled_route import ScheduledRouteBuilder
 
-__all__ = ["DelayedRouteBuilder", "ScheduledRouteBuilder"]
+__all__ = [
+    "AsyncDelayedRouteBuilder",
+    "AsyncScheduledRouteBuilder",
+    "DelayedRouteBuilder",
+    "ScheduledRouteBuilder",
+]

--- a/fastapi_gcp_tasks/async_clients.py
+++ b/fastapi_gcp_tasks/async_clients.py
@@ -1,0 +1,49 @@
+# Standard Library Imports
+import asyncio
+from typing import Callable, Generic, TypeVar
+
+ClientT = TypeVar("ClientT")
+
+
+class AsyncClientProvider(Generic[ClientT]):
+    """
+    Lazily resolves and caches an async gRPC client inside the running event loop.
+
+    grpc.aio channels bind to the event loop active at construction, so the client
+    (or client factory) is only resolved on first use, from within the loop that
+    will await the RPCs. One provider should be shared per route builder so all
+    calls reuse the same client and channel.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: "ClientT | Callable[[], ClientT] | None",
+        client_cls: type[ClientT],
+    ) -> None:
+        self._client_or_factory = client
+        self._client_cls = client_cls
+        self._client: ClientT | None = None
+        self._lock = asyncio.Lock()
+
+    async def get(self) -> ClientT:
+        """Return the cached client, resolving it on first call."""
+        if self._client is not None:
+            return self._client
+        async with self._lock:
+            if self._client is None:
+                self._client = self._resolve()
+            return self._client
+
+    def _resolve(self) -> ClientT:
+        client = self._client_or_factory
+        if client is None:
+            return self._client_cls()
+        if isinstance(client, self._client_cls):
+            return client
+        if callable(client):
+            return client()
+        raise TypeError(
+            f"client must be a {self._client_cls.__name__}, a zero-argument factory returning one, or None; "
+            f"got {type(client).__name__}"
+        )

--- a/fastapi_gcp_tasks/async_clients.py
+++ b/fastapi_gcp_tasks/async_clients.py
@@ -42,7 +42,12 @@ class AsyncClientProvider(Generic[ClientT]):
         if isinstance(client, self._client_cls):
             return client
         if callable(client):
-            return client()
+            resolved = client()
+            if not isinstance(resolved, self._client_cls):
+                raise TypeError(
+                    f"client factory must return a {self._client_cls.__name__}; got {type(resolved).__name__}"
+                )
+            return resolved
         raise TypeError(
             f"client must be a {self._client_cls.__name__}, a zero-argument factory returning one, or None; "
             f"got {type(client).__name__}"

--- a/fastapi_gcp_tasks/async_delayed_route.py
+++ b/fastapi_gcp_tasks/async_delayed_route.py
@@ -1,0 +1,108 @@
+# Standard Library Imports
+from typing import Callable, Type
+
+# Third Party Imports
+from fastapi.routing import APIRoute
+from google.cloud import tasks_v2
+
+# Imports from this repository
+from fastapi_gcp_tasks.async_delayer import (
+    AsyncCloudTasksClientFactory,
+    AsyncCloudTasksClientProvider,
+    AsyncDelayer,
+)
+from fastapi_gcp_tasks.hooks import DelayedTaskHook, noop_hook
+
+
+def AsyncDelayedRouteBuilder(  # noqa: N802
+    *,
+    base_url: str,
+    queue_path: str,
+    task_create_timeout: float = 10.0,
+    pre_create_hook: DelayedTaskHook | None = None,
+    client: tasks_v2.CloudTasksAsyncClient | AsyncCloudTasksClientFactory | None = None,
+    auto_create_queue: bool = False,
+) -> Type[APIRoute]:
+    """
+    Returns a Mixin that should be used to override route_class, with an awaitable .delay.
+
+    It adds awaitable .delay and sync .options methods to the original endpoint.
+
+    ``client`` may be a CloudTasksAsyncClient, a zero-argument factory returning one,
+    or None (default client). grpc.aio channels bind to the event loop active at
+    construction, so the client is resolved lazily on the first awaited ``.delay()``
+    inside the running loop; pass a factory if your client needs custom construction
+    (e.g. the emulator).
+
+    Unlike DelayedRouteBuilder, ``auto_create_queue`` defaults to False so no
+    unexpected RPCs run inside request handlers. Either pass
+    ``auto_create_queue=True`` to lazily ensure the queue on the first
+    ``.delay()``, or call ``fastapi_gcp_tasks.utils.ensure_queue_async`` from your
+    FastAPI lifespan (recommended).
+
+    Example:
+    -------
+    ```
+      async_delayed_router = APIRouter(route_class=AsyncDelayedRouteBuilder(...), prefix="/delayed")
+
+      class UserData(BaseModel):
+          name: str
+
+      @async_delayed_router.post("/on_user_create/{user_id}")
+      async def on_user_create(user_id: str, data: UserData):
+          # do work here
+          # Return values are meaningless
+
+      # Await .delay to trigger
+      await on_user_create.delay(user_id="007", data=UserData(name="Piyush"))
+
+      app.include_router(async_delayed_router)
+    ```
+
+    """
+    if pre_create_hook is None:
+        pre_create_hook = noop_hook
+
+    client_provider = AsyncCloudTasksClientProvider(
+        client=client,
+        queue_path=queue_path,
+        auto_create_queue=auto_create_queue,
+    )
+
+    class AsyncTaskRouteMixin(APIRoute):
+        def get_route_handler(self) -> Callable:
+            original_route_handler = super().get_route_handler()
+            self.endpoint.options = self.delay_options  # type: ignore[attr-defined]
+            self.endpoint.delay = self.delay  # type: ignore[attr-defined]
+            return original_route_handler
+
+        def delay_options(self, **options: dict) -> AsyncDelayer:
+            delay_opts = {
+                "base_url": base_url,
+                "queue_path": queue_path,
+                "task_create_timeout": task_create_timeout,
+                "client_provider": client_provider,
+                "pre_create_hook": pre_create_hook,
+            }
+            if hasattr(self.endpoint, "_delay_options"):
+                delay_opts |= self.endpoint._delay_options
+            delay_opts |= options
+
+            # A per-call client override gets its own one-off provider
+            if "client" in delay_opts:
+                delay_opts["client_provider"] = AsyncCloudTasksClientProvider(
+                    client=delay_opts.pop("client"),  # type: ignore[arg-type]
+                    queue_path=str(delay_opts["queue_path"]),
+                    auto_create_queue=auto_create_queue,
+                )
+
+            # ignoring the type here because the dictionary values are unpacked
+            return AsyncDelayer(
+                route=self,
+                **delay_opts,  # type: ignore[arg-type]
+            )
+
+        async def delay(self, **kwargs: dict) -> tasks_v2.Task:
+            return await self.delay_options().delay(**kwargs)
+
+    return AsyncTaskRouteMixin

--- a/fastapi_gcp_tasks/async_delayed_route.py
+++ b/fastapi_gcp_tasks/async_delayed_route.py
@@ -1,5 +1,5 @@
 # Standard Library Imports
-from typing import Callable, Type
+from typing import Any, Callable, Type
 
 # Third Party Imports
 from fastapi.routing import APIRoute
@@ -76,7 +76,7 @@ def AsyncDelayedRouteBuilder(  # noqa: N802
             self.endpoint.delay = self.delay  # type: ignore[attr-defined]
             return original_route_handler
 
-        def delay_options(self, **options: dict) -> AsyncDelayer:
+        def delay_options(self, **options: Any) -> AsyncDelayer:
             delay_opts = {
                 "base_url": base_url,
                 "queue_path": queue_path,
@@ -102,7 +102,7 @@ def AsyncDelayedRouteBuilder(  # noqa: N802
                 **delay_opts,  # type: ignore[arg-type]
             )
 
-        async def delay(self, **kwargs: dict) -> tasks_v2.Task:
+        async def delay(self, **kwargs: Any) -> tasks_v2.Task:
             return await self.delay_options().delay(**kwargs)
 
     return AsyncTaskRouteMixin

--- a/fastapi_gcp_tasks/async_delayed_route.py
+++ b/fastapi_gcp_tasks/async_delayed_route.py
@@ -63,11 +63,7 @@ def AsyncDelayedRouteBuilder(  # noqa: N802
     if pre_create_hook is None:
         pre_create_hook = noop_hook
 
-    client_provider = AsyncCloudTasksClientProvider(
-        client=client,
-        queue_path=queue_path,
-        auto_create_queue=auto_create_queue,
-    )
+    client_provider = AsyncCloudTasksClientProvider(client=client, auto_create_queue=auto_create_queue)
 
     class AsyncTaskRouteMixin(APIRoute):
         def get_route_handler(self) -> Callable:
@@ -92,7 +88,6 @@ def AsyncDelayedRouteBuilder(  # noqa: N802
             if "client" in delay_opts:
                 delay_opts["client_provider"] = AsyncCloudTasksClientProvider(
                     client=delay_opts.pop("client"),  # type: ignore[arg-type]
-                    queue_path=str(delay_opts["queue_path"]),
                     auto_create_queue=auto_create_queue,
                 )
 

--- a/fastapi_gcp_tasks/async_delayer.py
+++ b/fastapi_gcp_tasks/async_delayer.py
@@ -19,14 +19,13 @@ class AsyncCloudTasksClientProvider(AsyncClientProvider[tasks_v2.CloudTasksAsync
     """
     Lazily resolves and caches a CloudTasksAsyncClient inside the running event loop.
 
-    If ``auto_create_queue`` is True, the queue is ensured exactly once before the
-    client is first handed out; a failed ensure is retried on the next call while
-    the already-resolved client stays cached.
+    If ``auto_create_queue`` is True, each queue path requested via ``get_for_queue``
+    is ensured exactly once before the client is handed out; a failed ensure is
+    retried on the next call while the already-resolved client stays cached.
 
     Attributes
     ----------
-        queue_path (str): The path to the Cloud Tasks queue.
-        auto_create_queue (bool): Whether to ensure the queue exists on first use.
+        auto_create_queue (bool): Whether to ensure queues exist on first use.
 
     """
 
@@ -34,23 +33,21 @@ class AsyncCloudTasksClientProvider(AsyncClientProvider[tasks_v2.CloudTasksAsync
         self,
         *,
         client: tasks_v2.CloudTasksAsyncClient | AsyncCloudTasksClientFactory | None,
-        queue_path: str,
         auto_create_queue: bool = False,
     ) -> None:
         super().__init__(client=client, client_cls=tasks_v2.CloudTasksAsyncClient)
-        self.queue_path = queue_path
         self.auto_create_queue = auto_create_queue
-        self._queue_ensured = not auto_create_queue
+        self._ensured_queues: set[str] = set()
         self._ensure_lock = asyncio.Lock()
 
-    async def get(self) -> tasks_v2.CloudTasksAsyncClient:
-        """Return the cached client, ensuring the queue exists on first call if configured."""
-        client = await super().get()
-        if not self._queue_ensured:
+    async def get_for_queue(self, *, queue_path: str) -> tasks_v2.CloudTasksAsyncClient:
+        """Return the cached client, ensuring the given queue exists first if configured."""
+        client = await self.get()
+        if self.auto_create_queue and queue_path not in self._ensured_queues:
             async with self._ensure_lock:
-                if not self._queue_ensured:
-                    await ensure_queue_async(client=client, path=self.queue_path)
-                    self._queue_ensured = True
+                if queue_path not in self._ensured_queues:
+                    await ensure_queue_async(client=client, path=queue_path)
+                    self._ensured_queues.add(queue_path)
         return client
 
 
@@ -91,6 +88,6 @@ class AsyncDelayer(BaseDelayer):
 
     async def delay(self, **kwargs: Any) -> tasks_v2.Task:
         """Delay a task on Cloud Tasks without blocking the event loop."""
-        client = await self.client_provider.get()
+        client = await self.client_provider.get_for_queue(queue_path=self.queue_path)
         request = self._build_create_task_request(values=kwargs)
         return await client.create_task(request=request, timeout=self.task_create_timeout)

--- a/fastapi_gcp_tasks/async_delayer.py
+++ b/fastapi_gcp_tasks/async_delayer.py
@@ -1,0 +1,96 @@
+# Standard Library Imports
+import asyncio
+from typing import Any, Callable
+
+# Third Party Imports
+from fastapi.routing import APIRoute
+from google.cloud import tasks_v2
+
+# Imports from this repository
+from fastapi_gcp_tasks.async_clients import AsyncClientProvider
+from fastapi_gcp_tasks.delayer import BaseDelayer
+from fastapi_gcp_tasks.hooks import DelayedTaskHook
+from fastapi_gcp_tasks.utils import ensure_queue_async
+
+AsyncCloudTasksClientFactory = Callable[[], tasks_v2.CloudTasksAsyncClient]
+
+
+class AsyncCloudTasksClientProvider(AsyncClientProvider[tasks_v2.CloudTasksAsyncClient]):
+    """
+    Lazily resolves and caches a CloudTasksAsyncClient inside the running event loop.
+
+    If ``auto_create_queue`` is True, the queue is ensured exactly once before the
+    client is first handed out; a failed ensure is retried on the next call while
+    the already-resolved client stays cached.
+
+    Attributes
+    ----------
+        queue_path (str): The path to the Cloud Tasks queue.
+        auto_create_queue (bool): Whether to ensure the queue exists on first use.
+
+    """
+
+    def __init__(
+        self,
+        *,
+        client: tasks_v2.CloudTasksAsyncClient | AsyncCloudTasksClientFactory | None,
+        queue_path: str,
+        auto_create_queue: bool = False,
+    ) -> None:
+        super().__init__(client=client, client_cls=tasks_v2.CloudTasksAsyncClient)
+        self.queue_path = queue_path
+        self.auto_create_queue = auto_create_queue
+        self._queue_ensured = not auto_create_queue
+        self._ensure_lock = asyncio.Lock()
+
+    async def get(self) -> tasks_v2.CloudTasksAsyncClient:
+        """Return the cached client, ensuring the queue exists on first call if configured."""
+        client = await super().get()
+        if not self._queue_ensured:
+            async with self._ensure_lock:
+                if not self._queue_ensured:
+                    await ensure_queue_async(client=client, path=self.queue_path)
+                    self._queue_ensured = True
+        return client
+
+
+class AsyncDelayer(BaseDelayer):
+    """
+    A class to delay HTTP requests as tasks on Google Cloud Tasks, using an async client.
+
+    See BaseDelayer for the shared attributes.
+
+    Attributes
+    ----------
+        client_provider (AsyncCloudTasksClientProvider): Lazy provider for the async client.
+
+    """
+
+    def __init__(
+        self,
+        *,
+        route: APIRoute,
+        base_url: str,
+        queue_path: str,
+        client_provider: AsyncCloudTasksClientProvider,
+        pre_create_hook: DelayedTaskHook,
+        task_create_timeout: float = 10.0,
+        countdown: int = 0,
+        task_id: str | None = None,
+    ) -> None:
+        super().__init__(
+            route=route,
+            base_url=base_url,
+            queue_path=queue_path,
+            pre_create_hook=pre_create_hook,
+            task_create_timeout=task_create_timeout,
+            countdown=countdown,
+            task_id=task_id,
+        )
+        self.client_provider = client_provider
+
+    async def delay(self, **kwargs: Any) -> tasks_v2.Task:
+        """Delay a task on Cloud Tasks without blocking the event loop."""
+        client = await self.client_provider.get()
+        request = self._build_create_task_request(values=kwargs)
+        return await client.create_task(request=request, timeout=self.task_create_timeout)

--- a/fastapi_gcp_tasks/async_scheduled_route.py
+++ b/fastapi_gcp_tasks/async_scheduled_route.py
@@ -1,5 +1,5 @@
 # Standard Library Imports
-from typing import Callable, Type
+from typing import Any, Callable, Type
 
 # Third Party Imports
 from fastapi.routing import APIRoute
@@ -61,7 +61,7 @@ def AsyncScheduledRouteBuilder(  # noqa: N802
             self.endpoint.scheduler = self.scheduler_options  # type: ignore[attr-defined]
             return original_route_handler
 
-        def scheduler_options(self, *, name: str, schedule: str, **options: dict) -> AsyncScheduler:
+        def scheduler_options(self, *, name: str, schedule: str, **options: Any) -> AsyncScheduler:
             scheduler_opts = {
                 "base_url": base_url,
                 "location_path": location_path,

--- a/fastapi_gcp_tasks/async_scheduled_route.py
+++ b/fastapi_gcp_tasks/async_scheduled_route.py
@@ -1,0 +1,85 @@
+# Standard Library Imports
+from typing import Callable, Type
+
+# Third Party Imports
+from fastapi.routing import APIRoute
+from google.cloud import scheduler_v1
+
+# Imports from this repository
+from fastapi_gcp_tasks.async_clients import AsyncClientProvider
+from fastapi_gcp_tasks.async_scheduler import AsyncCloudSchedulerClientFactory, AsyncScheduler
+from fastapi_gcp_tasks.hooks import ScheduledHook, noop_hook
+
+
+def AsyncScheduledRouteBuilder(  # noqa: N802
+    *,
+    base_url: str,
+    location_path: str,
+    job_create_timeout: float = 10.0,
+    pre_create_hook: ScheduledHook | None = None,
+    client: scheduler_v1.CloudSchedulerAsyncClient | AsyncCloudSchedulerClientFactory | None = None,
+) -> Type[APIRoute]:
+    """
+    Returns a Mixin that should be used to override route_class, with an awaitable scheduler.
+
+    It adds a .scheduler method to the original endpoint whose .schedule and .delete
+    coroutines must be awaited. Unlike ScheduledRouteBuilder, .schedule() cannot run at
+    module import time — await it from a FastAPI lifespan or a request handler.
+
+    ``client`` may be a CloudSchedulerAsyncClient, a zero-argument factory returning
+    one, or None (default client). grpc.aio channels bind to the event loop active at
+    construction, so the client is resolved lazily on the first awaited call; pass a
+    factory if your client needs custom construction.
+
+    Example:
+    -------
+    ```
+    async_scheduled_router = APIRouter(route_class=AsyncScheduledRouteBuilder(...), prefix="/scheduled")
+
+    @async_scheduled_router.get("/simple_scheduled_task")
+    async def simple_scheduled_task():
+        # Do work here
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        await simple_scheduled_task.scheduler(name="simple_scheduled_task", schedule="* * * * *").schedule()
+        yield
+
+    app.include_router(async_scheduled_router)
+    ```
+
+    """
+    if pre_create_hook is None:
+        pre_create_hook = noop_hook
+
+    # One provider per builder so every scheduler reuses the same client and channel
+    client_provider = AsyncClientProvider(client=client, client_cls=scheduler_v1.CloudSchedulerAsyncClient)
+
+    class AsyncScheduledRouteMixin(APIRoute):
+        def get_route_handler(self) -> Callable:
+            original_route_handler = super().get_route_handler()
+            self.endpoint.scheduler = self.scheduler_options  # type: ignore[attr-defined]
+            return original_route_handler
+
+        def scheduler_options(self, *, name: str, schedule: str, **options: dict) -> AsyncScheduler:
+            scheduler_opts = {
+                "base_url": base_url,
+                "location_path": location_path,
+                "client_provider": client_provider,
+                "pre_create_hook": pre_create_hook,
+                "job_create_timeout": job_create_timeout,
+                "name": name,
+                "schedule": schedule,
+            } | options
+
+            # A per-call client override gets its own one-off provider
+            if "client" in scheduler_opts:
+                scheduler_opts["client_provider"] = AsyncClientProvider(
+                    client=scheduler_opts.pop("client"),  # type: ignore[arg-type]
+                    client_cls=scheduler_v1.CloudSchedulerAsyncClient,
+                )
+
+            # ignoring the type here because the dictionary values are unpacked
+            return AsyncScheduler(route=self, **scheduler_opts)  # type: ignore[arg-type]
+
+    return AsyncScheduledRouteMixin

--- a/fastapi_gcp_tasks/async_scheduler.py
+++ b/fastapi_gcp_tasks/async_scheduler.py
@@ -1,0 +1,86 @@
+# Standard Library Imports
+from typing import Any, Callable
+
+# Third Party Imports
+from fastapi.routing import APIRoute
+from google.cloud import scheduler_v1
+
+# Imports from this repository
+from fastapi_gcp_tasks.async_clients import AsyncClientProvider
+from fastapi_gcp_tasks.hooks import ScheduledHook
+from fastapi_gcp_tasks.scheduler import BaseScheduler
+
+AsyncCloudSchedulerClientFactory = Callable[[], scheduler_v1.CloudSchedulerAsyncClient]
+
+
+class AsyncScheduler(BaseScheduler):
+    """
+    A class to schedule HTTP requests as jobs on Google Cloud Scheduler, using an async client.
+
+    See BaseScheduler for the shared attributes.
+
+    Attributes
+    ----------
+        client_provider (AsyncClientProvider): Lazy provider for the async client. Share one
+            provider across schedulers so they reuse the same client and gRPC channel.
+
+    """
+
+    def __init__(
+        self,
+        *,
+        route: APIRoute,
+        base_url: str,
+        location_path: str,
+        schedule: str,
+        pre_create_hook: ScheduledHook,
+        client_provider: AsyncClientProvider[scheduler_v1.CloudSchedulerAsyncClient],
+        name: str = "",
+        job_create_timeout: float = 10.0,
+        retry_config: scheduler_v1.RetryConfig | None = None,
+        time_zone: str = "UTC",
+        force: bool = False,
+    ) -> None:
+        super().__init__(
+            route=route,
+            base_url=base_url,
+            location_path=location_path,
+            schedule=schedule,
+            pre_create_hook=pre_create_hook,
+            name=name,
+            job_create_timeout=job_create_timeout,
+            retry_config=retry_config,
+            time_zone=time_zone,
+            force=force,
+        )
+        self.client_provider = client_provider
+
+    async def schedule(self, **kwargs: Any) -> None:
+        """Schedule a job on Cloud Scheduler without blocking the event loop."""
+        request = self._build_create_job_request(values=kwargs)
+
+        if self.force or await self._has_changed(request=request):
+            # Delete and create job
+            await self.delete()
+            client = await self.client_provider.get()
+            await client.create_job(request=request, timeout=self.job_create_timeout)
+
+    async def _has_changed(self, request: scheduler_v1.CreateJobRequest) -> bool:
+        try:
+            client = await self.client_provider.get()
+            job = await client.get_job(name=request.job.name)
+            return self._job_changed(job=job, request=request)
+        # TODO: replace this with a more specific exception
+        except Exception:  # noqa: BLE001
+            return True
+
+    async def delete(self) -> bool | Exception:
+        """Delete the job from the scheduler if it exists."""
+        # We return true or exception because you could have the delete code on multiple instances
+        try:
+            client = await self.client_provider.get()
+            await client.delete_job(name=self.job_id, timeout=self.job_create_timeout)
+            return True
+        # TODO: replace this with a more specific exception. we may also just raise the exception here?
+        except Exception as ex:  # noqa: BLE001
+            return ex

--- a/fastapi_gcp_tasks/delayed_route.py
+++ b/fastapi_gcp_tasks/delayed_route.py
@@ -1,5 +1,5 @@
 # Standard Library Imports
-from typing import Callable, Type
+from typing import Any, Callable, Type
 
 # Third Party Imports
 from fastapi.routing import APIRoute
@@ -61,7 +61,7 @@ def DelayedRouteBuilder(  # noqa: N802
             self.endpoint.delay = self.delay  # type: ignore[attr-defined]
             return original_route_handler
 
-        def delay_options(self, **options: dict) -> Delayer:
+        def delay_options(self, **options: Any) -> Delayer:
             delay_opts = {
                 "base_url": base_url,
                 "queue_path": queue_path,
@@ -79,7 +79,7 @@ def DelayedRouteBuilder(  # noqa: N802
                 **delay_opts,  # type: ignore[arg-type]
             )
 
-        def delay(self, **kwargs: dict) -> tasks_v2.Task:
+        def delay(self, **kwargs: Any) -> tasks_v2.Task:
             return self.delay_options().delay(**kwargs)
 
     return TaskRouteMixin

--- a/fastapi_gcp_tasks/delayer.py
+++ b/fastapi_gcp_tasks/delayer.py
@@ -13,9 +13,9 @@ from fastapi_gcp_tasks.hooks import DelayedTaskHook
 from fastapi_gcp_tasks.requester import Requester
 
 
-class Delayer(Requester):
+class BaseDelayer(Requester):
     """
-    A class to delay HTTP requests as tasks on Google Cloud Tasks.
+    Shared logic to build Cloud Tasks requests from FastAPI routes.
 
     Attributes
     ----------
@@ -24,8 +24,72 @@ class Delayer(Requester):
         task_create_timeout (float): Timeout for creating the task.
         task_id (str): The unique identifier for the task.
         method (tasks_v2.HttpMethod): The HTTP method for the task.
-        client (tasks_v2.CloudTasksClient): The Cloud Tasks client.
         pre_create_hook (DelayedTaskHook): Hook to be called before creating the task.
+
+    """
+
+    def __init__(
+        self,
+        *,
+        route: APIRoute,
+        base_url: str,
+        queue_path: str,
+        pre_create_hook: DelayedTaskHook,
+        task_create_timeout: float = 10.0,
+        countdown: int = 0,
+        task_id: str | None = None,
+    ) -> None:
+        super().__init__(route=route, base_url=base_url)
+        self.queue_path = queue_path
+        self.countdown = countdown
+        self.task_create_timeout = task_create_timeout
+
+        self.task_id = task_id
+        self.method = _task_method(route.methods)
+        self.pre_create_hook = pre_create_hook
+
+    def _build_create_task_request(self, *, values: dict[str, Any]) -> tasks_v2.CreateTaskRequest:
+        """Build the CreateTaskRequest (including the pre-create hook) for the given endpoint arguments."""
+        # Create http request
+        http_request = tasks_v2.HttpRequest()
+        http_request.http_method = self.method
+        http_request.url = self._url(values=values)
+        http_request.headers = self._headers(values=values)
+
+        if body := self._body(values=values):
+            http_request.body = body
+
+        # Scheduled the task
+        task = tasks_v2.Task(http_request=http_request)
+        if schedule_time := self._schedule():
+            task.schedule_time = schedule_time
+
+        # Make task name for deduplication
+        if self.task_id:
+            task.name = f"{self.queue_path}/tasks/{self.task_id}"
+
+        request = tasks_v2.CreateTaskRequest(parent=self.queue_path, task=task)
+
+        return self.pre_create_hook(request)
+
+    def _schedule(self) -> timestamp_pb2.Timestamp | None:
+        if self.countdown is None or self.countdown <= 0:
+            return None
+        d = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=self.countdown)
+        timestamp = timestamp_pb2.Timestamp()
+        timestamp.FromDatetime(d)
+        return timestamp
+
+
+class Delayer(BaseDelayer):
+    """
+    A class to delay HTTP requests as tasks on Google Cloud Tasks.
+
+    See BaseDelayer for the shared attributes.
+
+    Attributes
+    ----------
+        client (tasks_v2.CloudTasksClient): The Cloud Tasks client.
 
     """
 
@@ -41,49 +105,21 @@ class Delayer(Requester):
         countdown: int = 0,
         task_id: str | None = None,
     ) -> None:
-        super().__init__(route=route, base_url=base_url)
-        self.queue_path = queue_path
-        self.countdown = countdown
-        self.task_create_timeout = task_create_timeout
-
-        self.task_id = task_id
-        self.method = _task_method(route.methods)
+        super().__init__(
+            route=route,
+            base_url=base_url,
+            queue_path=queue_path,
+            pre_create_hook=pre_create_hook,
+            task_create_timeout=task_create_timeout,
+            countdown=countdown,
+            task_id=task_id,
+        )
         self.client = client
-        self.pre_create_hook = pre_create_hook
 
     def delay(self, **kwargs: Any) -> tasks_v2.Task:
         """Delay a task on Cloud Tasks."""
-        # Create http request
-        request = tasks_v2.HttpRequest()
-        request.http_method = self.method
-        request.url = self._url(values=kwargs)
-        request.headers = self._headers(values=kwargs)
-
-        if body := self._body(values=kwargs):
-            request.body = body
-
-        # Scheduled the task
-        task = tasks_v2.Task(http_request=request)
-        if schedule_time := self._schedule():
-            task.schedule_time = schedule_time
-
-        # Make task name for deduplication
-        if self.task_id:
-            task.name = f"{self.queue_path}/tasks/{self.task_id}"
-
-        request = tasks_v2.CreateTaskRequest(parent=self.queue_path, task=task)
-
-        request = self.pre_create_hook(request)
-
+        request = self._build_create_task_request(values=kwargs)
         return self.client.create_task(request=request, timeout=self.task_create_timeout)
-
-    def _schedule(self) -> timestamp_pb2.Timestamp | None:
-        if self.countdown is None or self.countdown <= 0:
-            return None
-        d = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=self.countdown)
-        timestamp = timestamp_pb2.Timestamp()
-        timestamp.FromDatetime(d)
-        return timestamp
 
 
 def _task_method(methods: Iterable[str] | None) -> tasks_v2.HttpMethod:

--- a/fastapi_gcp_tasks/scheduled_route.py
+++ b/fastapi_gcp_tasks/scheduled_route.py
@@ -1,5 +1,5 @@
 # Standard Library Imports
-from typing import Callable, Type
+from typing import Any, Callable, Type
 
 # Third Party Imports
 from fastapi.routing import APIRoute
@@ -50,7 +50,7 @@ def ScheduledRouteBuilder(  # noqa: N802
             self.endpoint.scheduler = self.scheduler_options  # type: ignore[attr-defined]
             return original_route_handler
 
-        def scheduler_options(self, *, name: str, schedule: str, **options: dict) -> Scheduler:
+        def scheduler_options(self, *, name: str, schedule: str, **options: Any) -> Scheduler:
             scheduler_opts = {
                 "base_url": base_url,
                 "location_path": location_path,
@@ -61,7 +61,6 @@ def ScheduledRouteBuilder(  # noqa: N802
                 "schedule": schedule,
             } | options
 
-            # ignoring the type here because the dictionary values are unpacked
-            return Scheduler(route=self, **scheduler_opts)  # type: ignore[arg-type]
+            return Scheduler(route=self, **scheduler_opts)
 
     return ScheduledRouteMixin

--- a/fastapi_gcp_tasks/scheduler.py
+++ b/fastapi_gcp_tasks/scheduler.py
@@ -107,7 +107,7 @@ class BaseScheduler(Requester):
         job.status = None
         job.last_attempt_time = None  # type: ignore[assignment]
         job.schedule_time = None  # type: ignore[assignment]
-        del job.http_target.headers["User-Agent"]
+        job.http_target.headers.pop("User-Agent", None)
         # Proto compare works directly with `__eq__`
         return job != request.job
 

--- a/fastapi_gcp_tasks/scheduler.py
+++ b/fastapi_gcp_tasks/scheduler.py
@@ -12,9 +12,9 @@ from fastapi_gcp_tasks.hooks import ScheduledHook
 from fastapi_gcp_tasks.requester import Requester
 
 
-class Scheduler(Requester):
+class BaseScheduler(Requester):
     """
-    A class to schedule HTTP requests as jobs on Google Cloud Scheduler.
+    Shared logic to build Cloud Scheduler job requests from FastAPI routes.
 
     Attributes
     ----------
@@ -25,7 +25,6 @@ class Scheduler(Requester):
         cron_schedule (str): The cron schedule for the job.
         job_create_timeout (float): Timeout for creating the job.
         method (scheduler_v1.HttpMethod): The HTTP method for the job.
-        client (scheduler_v1.CloudSchedulerClient): The Cloud Scheduler client.
         pre_create_hook (ScheduledHook): Hook to be called before creating the job.
         force (bool): Whether to force create the job if it already exists.
 
@@ -38,7 +37,6 @@ class Scheduler(Requester):
         base_url: str,
         location_path: str,
         schedule: str,
-        client: scheduler_v1.CloudSchedulerClient,
         pre_create_hook: ScheduledHook,
         name: str = "",
         job_create_timeout: float = 10.0,
@@ -60,9 +58,11 @@ class Scheduler(Requester):
             )
 
         self.retry_config = retry_config
-        location_parts = client.parse_common_location_path(location_path)
+        # Path helpers are staticmethods shared by the sync and async clients,
+        # so we don't need a client instance here.
+        location_parts = scheduler_v1.CloudSchedulerClient.parse_common_location_path(location_path)
 
-        self.job_id = client.job_path(job=name, **location_parts)
+        self.job_id = scheduler_v1.CloudSchedulerClient.job_path(job=name, **location_parts)
         self.time_zone = time_zone
 
         self.location_path = location_path
@@ -70,26 +70,25 @@ class Scheduler(Requester):
         self.job_create_timeout = job_create_timeout
 
         self.method = _scheduler_method(route.methods)
-        self.client = client
         self.pre_create_hook = pre_create_hook
         self.force = force
 
-    def schedule(self, **kwargs: Any) -> None:
-        """Schedule a job on Cloud Scheduler."""
+    def _build_create_job_request(self, *, values: dict[str, Any]) -> scheduler_v1.CreateJobRequest:
+        """Build the CreateJobRequest (including the pre-create hook) for the given endpoint arguments."""
         # Create http request
-        request = scheduler_v1.HttpTarget()
-        request.http_method = self.method
-        request.uri = self._url(values=kwargs)
-        request.headers = self._headers(values=kwargs)
+        http_target = scheduler_v1.HttpTarget()
+        http_target.http_method = self.method
+        http_target.uri = self._url(values=values)
+        http_target.headers = self._headers(values=values)
 
-        body = self._body(values=kwargs)
+        body = self._body(values=values)
         if body:
-            request.body = body
+            http_target.body = body
 
         # Scheduled the task
         job = scheduler_v1.Job(
             name=self.job_id,
-            http_target=request,
+            http_target=http_target,
             schedule=self.cron_schedule,
             retry_config=self.retry_config,
             time_zone=self.time_zone,
@@ -97,7 +96,66 @@ class Scheduler(Requester):
 
         request = scheduler_v1.CreateJobRequest(parent=self.location_path, job=job)
 
-        request = self.pre_create_hook(request)
+        return self.pre_create_hook(request)
+
+    @staticmethod
+    def _job_changed(*, job: scheduler_v1.Job, request: scheduler_v1.CreateJobRequest) -> bool:
+        """Compare an existing job against the job we want to create, ignoring output-only fields."""
+        # Remove things that are either output only or GCP adds by default
+        job.user_update_time = None  # type: ignore[assignment]
+        job.state = None  # type: ignore[assignment]
+        job.status = None
+        job.last_attempt_time = None  # type: ignore[assignment]
+        job.schedule_time = None  # type: ignore[assignment]
+        del job.http_target.headers["User-Agent"]
+        # Proto compare works directly with `__eq__`
+        return job != request.job
+
+
+class Scheduler(BaseScheduler):
+    """
+    A class to schedule HTTP requests as jobs on Google Cloud Scheduler.
+
+    See BaseScheduler for the shared attributes.
+
+    Attributes
+    ----------
+        client (scheduler_v1.CloudSchedulerClient): The Cloud Scheduler client.
+
+    """
+
+    def __init__(
+        self,
+        *,
+        route: APIRoute,
+        base_url: str,
+        location_path: str,
+        schedule: str,
+        client: scheduler_v1.CloudSchedulerClient,
+        pre_create_hook: ScheduledHook,
+        name: str = "",
+        job_create_timeout: float = 10.0,
+        retry_config: scheduler_v1.RetryConfig | None = None,
+        time_zone: str = "UTC",
+        force: bool = False,
+    ) -> None:
+        super().__init__(
+            route=route,
+            base_url=base_url,
+            location_path=location_path,
+            schedule=schedule,
+            pre_create_hook=pre_create_hook,
+            name=name,
+            job_create_timeout=job_create_timeout,
+            retry_config=retry_config,
+            time_zone=time_zone,
+            force=force,
+        )
+        self.client = client
+
+    def schedule(self, **kwargs: Any) -> None:
+        """Schedule a job on Cloud Scheduler."""
+        request = self._build_create_job_request(values=kwargs)
 
         if self.force or self._has_changed(request=request):
             # Delete and create job
@@ -107,19 +165,10 @@ class Scheduler(Requester):
     def _has_changed(self, request: scheduler_v1.CreateJobRequest) -> bool:
         try:
             job = self.client.get_job(name=request.job.name)
-            # Remove things that are either output only or GCP adds by default
-            job.user_update_time = None  # type: ignore[assignment]
-            job.state = None  # type: ignore[assignment]
-            job.status = None
-            job.last_attempt_time = None  # type: ignore[assignment]
-            job.schedule_time = None  # type: ignore[assignment]
-            del job.http_target.headers["User-Agent"]
-            # Proto compare works directly with `__eq__`
-            return job != request.job
+            return self._job_changed(job=job, request=request)
         # TODO: replace this with a more specific exception
         except Exception:  # noqa: BLE001
             return True
-        return False
 
     def delete(self) -> bool | Exception:
         """Delete the job from the scheduler if it exists."""

--- a/fastapi_gcp_tasks/utils.py
+++ b/fastapi_gcp_tasks/utils.py
@@ -17,6 +17,15 @@ def queue_path(*, project: str, location: str, queue: str) -> str:
     return tasks_v2.CloudTasksClient.queue_path(project=project, location=location, queue=queue)
 
 
+def _create_queue_request(*, path: str, **kwargs: Any) -> tasks_v2.CreateQueueRequest:
+    # We extract information from the queue path to make the public api simpler
+    parsed_queue_path = tasks_v2.CloudTasksClient.parse_queue_path(path=path)
+    return tasks_v2.CreateQueueRequest(
+        parent=location_path(project=parsed_queue_path["project"], location=parsed_queue_path["location"]),
+        queue=tasks_v2.Queue(name=path, **kwargs),
+    )
+
+
 def ensure_queue(
     *,
     client: tasks_v2.CloudTasksClient,
@@ -29,14 +38,28 @@ def ensure_queue(
     If the queue already exists, this function will not raise an error.
     If the queue does not exist, it will be created with the provided kwargs.
     """
-    # We extract information from the queue path to make the public api simpler
-    parsed_queue_path = client.parse_queue_path(path=path)
-    create_req = tasks_v2.CreateQueueRequest(
-        parent=location_path(project=parsed_queue_path["project"], location=parsed_queue_path["location"]),
-        queue=tasks_v2.Queue(name=path, **kwargs),
-    )
     try:
-        client.create_queue(request=create_req)
+        client.create_queue(request=_create_queue_request(path=path, **kwargs))
+    except AlreadyExists:
+        pass
+
+
+async def ensure_queue_async(
+    *,
+    client: tasks_v2.CloudTasksAsyncClient,
+    path: str,
+    **kwargs: Any,
+) -> None:
+    """
+    Helper function to ensure a Cloud Tasks queue exists, using an async client.
+
+    If the queue already exists, this function will not raise an error.
+    If the queue does not exist, it will be created with the provided kwargs.
+
+    Recommended usage is to call this once from your FastAPI lifespan.
+    """
+    try:
+        await client.create_queue(request=_create_queue_request(path=path, **kwargs))
     except AlreadyExists:
         pass
 
@@ -46,3 +69,16 @@ def emulator_client(*, host: str = "localhost:8123") -> tasks_v2.CloudTasksClien
     channel = grpc.insecure_channel(host)
     transport = transports.CloudTasksGrpcTransport(channel=channel)
     return tasks_v2.CloudTasksClient(transport=transport)
+
+
+def async_emulator_client(*, host: str = "localhost:8123") -> tasks_v2.CloudTasksAsyncClient:
+    """
+    Helper function to create a CloudTasksAsyncClient from an emulator host.
+
+    Note: grpc.aio channels bind to the event loop active at construction, so call
+    this inside a running event loop, or pass it as a client factory to
+    AsyncDelayedRouteBuilder (e.g. ``client=lambda: async_emulator_client(host=...)``).
+    """
+    channel = grpc.aio.insecure_channel(host)
+    transport = transports.CloudTasksGrpcAsyncIOTransport(channel=channel)
+    return tasks_v2.CloudTasksAsyncClient(transport=transport)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,11 @@ dev = [
     "pytest>=8.3.3",
     "requests>=2.32.3",
     "pydantic-settings>=2.0.0",
+    "pytest-asyncio>=1.4.0",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]

--- a/tests/test_async_delayer.py
+++ b/tests/test_async_delayer.py
@@ -1,0 +1,218 @@
+"""Unit tests for AsyncDelayer and AsyncCloudTasksClientProvider using mocked async clients."""
+
+# Standard Library Imports
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+# Third Party Imports
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute
+from google.api_core.exceptions import ServiceUnavailable
+from google.cloud import tasks_v2
+from pydantic import BaseModel
+
+# Imports from this repository
+from fastapi_gcp_tasks.async_delayed_route import AsyncDelayedRouteBuilder
+from fastapi_gcp_tasks.async_delayer import AsyncCloudTasksClientProvider, AsyncDelayer
+from fastapi_gcp_tasks.delayer import Delayer
+from fastapi_gcp_tasks.hooks import noop_hook
+
+QUEUE_PATH = "projects/test-project/locations/us-central1/queues/test-queue"
+BASE_URL = "http://localhost"
+
+
+class Item(BaseModel):
+    """Simple model for testing."""
+
+    name: str
+
+
+def _make_route() -> APIRoute:
+    app = FastAPI()
+
+    @app.post("/hello/{user_id}")
+    async def hello(user_id: str, item: Item) -> None:
+        """Endpoint under test."""
+
+    for route in app.routes:
+        if isinstance(route, APIRoute) and route.path == "/hello/{user_id}":
+            return route
+    raise ValueError("Route not found")
+
+
+def _mock_async_client() -> MagicMock:
+    client = MagicMock(spec=tasks_v2.CloudTasksAsyncClient)
+    client.create_task = AsyncMock(return_value=tasks_v2.Task())
+    client.create_queue = AsyncMock(return_value=tasks_v2.Queue())
+    client.parse_queue_path = tasks_v2.CloudTasksClient.parse_queue_path
+    return client
+
+
+def _make_delayer(client: Any, *, auto_create_queue: bool = False, **kwargs: Any) -> AsyncDelayer:
+    provider = AsyncCloudTasksClientProvider(
+        client=client,
+        queue_path=QUEUE_PATH,
+        auto_create_queue=auto_create_queue,
+    )
+    return AsyncDelayer(
+        route=_make_route(),
+        base_url=BASE_URL,
+        queue_path=QUEUE_PATH,
+        client_provider=provider,
+        pre_create_hook=noop_hook,
+        **kwargs,
+    )
+
+
+class TestAsyncDelayer:
+    """Tests for AsyncDelayer.delay."""
+
+    async def test_delay_creates_task(self) -> None:
+        """delay() should await create_task with the built request."""
+        client = _mock_async_client()
+        delayer = _make_delayer(client)
+
+        result = await delayer.delay(user_id="007", item=Item(name="bond"))
+
+        assert isinstance(result, tasks_v2.Task)
+        client.create_task.assert_awaited_once()
+        request = client.create_task.await_args.kwargs["request"]
+        assert request.parent == QUEUE_PATH
+        assert request.task.http_request.url == f"{BASE_URL}/hello/007"
+        assert b"bond" in request.task.http_request.body
+
+    async def test_request_parity_with_sync_delayer(self) -> None:
+        """The async and sync delayers should build identical CreateTaskRequests."""
+        client = _mock_async_client()
+        async_delayer = _make_delayer(client)
+        sync_delayer = Delayer(
+            route=_make_route(),
+            base_url=BASE_URL,
+            queue_path=QUEUE_PATH,
+            client=MagicMock(spec=tasks_v2.CloudTasksClient),
+            pre_create_hook=noop_hook,
+        )
+        values = {"user_id": "007", "item": Item(name="bond")}
+
+        async_request = async_delayer._build_create_task_request(values=values)
+        sync_request = sync_delayer._build_create_task_request(values=values)
+
+        assert async_request == sync_request
+
+    async def test_delay_with_task_id_sets_name(self) -> None:
+        """A task_id should produce a deduplication name on the task."""
+        client = _mock_async_client()
+        delayer = _make_delayer(client, task_id="my-task")
+
+        await delayer.delay(user_id="007", item=Item(name="bond"))
+
+        request = client.create_task.await_args.kwargs["request"]
+        assert request.task.name == f"{QUEUE_PATH}/tasks/my-task"
+
+    async def test_delay_with_countdown_sets_schedule_time(self) -> None:
+        """A countdown should set schedule_time on the task."""
+        client = _mock_async_client()
+        delayer = _make_delayer(client, countdown=60)
+
+        await delayer.delay(user_id="007", item=Item(name="bond"))
+
+        request = client.create_task.await_args.kwargs["request"]
+        assert request.task.schedule_time is not None
+
+
+class TestAsyncCloudTasksClientProvider:
+    """Tests for lazy client resolution and queue auto-creation."""
+
+    async def test_factory_resolved_exactly_once(self) -> None:
+        """A client factory should be called once even across concurrent delays."""
+        client = _mock_async_client()
+        factory = MagicMock(return_value=client)
+        provider = AsyncCloudTasksClientProvider(client=factory, queue_path=QUEUE_PATH)
+
+        results = await asyncio.gather(*(provider.get() for _ in range(10)))
+
+        factory.assert_called_once()
+        assert all(r is client for r in results)
+
+    async def test_client_instance_used_as_is(self) -> None:
+        """A client instance should be returned unchanged."""
+        client = _mock_async_client()
+        provider = AsyncCloudTasksClientProvider(client=client, queue_path=QUEUE_PATH)
+
+        assert await provider.get() is client
+
+    async def test_no_auto_create_queue_by_default(self) -> None:
+        """The default must never call create_queue."""
+        client = _mock_async_client()
+        delayer = _make_delayer(client)
+
+        await delayer.delay(user_id="007", item=Item(name="bond"))
+
+        client.create_queue.assert_not_awaited()
+
+    async def test_auto_create_queue_ensures_once_across_concurrent_delays(self) -> None:
+        """auto_create_queue=True should ensure the queue exactly once under concurrency."""
+        client = _mock_async_client()
+        delayer = _make_delayer(client, auto_create_queue=True)
+
+        await asyncio.gather(*(delayer.delay(user_id=str(i), item=Item(name="x")) for i in range(10)))
+
+        client.create_queue.assert_awaited_once()
+        create_req = client.create_queue.await_args.kwargs["request"]
+        assert create_req.queue.name == QUEUE_PATH
+
+    async def test_failed_ensure_retries_without_recreating_client(self) -> None:
+        """A failed queue ensure should be retried on the next delay, reusing the cached client."""
+        client = _mock_async_client()
+        client.create_queue = AsyncMock(side_effect=[ServiceUnavailable("emulator down"), tasks_v2.Queue()])
+        factory = MagicMock(return_value=client)
+        delayer = _make_delayer(factory, auto_create_queue=True)
+
+        with pytest.raises(ServiceUnavailable):
+            await delayer.delay(user_id="007", item=Item(name="bond"))
+
+        result = await delayer.delay(user_id="007", item=Item(name="bond"))
+
+        assert isinstance(result, tasks_v2.Task)
+        factory.assert_called_once()
+        assert client.create_queue.await_count == 2
+
+    async def test_wrong_client_type_raises_clear_error(self) -> None:
+        """A non-async, non-factory client should fail with a descriptive TypeError."""
+        provider = AsyncCloudTasksClientProvider(client=object(), queue_path=QUEUE_PATH)  # type: ignore[arg-type]
+
+        with pytest.raises(TypeError, match="CloudTasksAsyncClient"):
+            await provider.get()
+
+
+class TestAsyncDelayedRouteBuilder:
+    """Tests for the route builder wiring."""
+
+    async def test_endpoint_gets_awaitable_delay(self) -> None:
+        """Endpoints on the async route should expose awaitable .delay and .options."""
+        client = _mock_async_client()
+        route_class = AsyncDelayedRouteBuilder(
+            base_url=BASE_URL,
+            queue_path=QUEUE_PATH,
+            client=client,
+        )
+        app = FastAPI()
+        router = APIRouter(route_class=route_class)
+
+        @router.post("/task/{user_id}")
+        async def my_task(user_id: str, item: Item) -> None:
+            """Task endpoint."""
+
+        app.include_router(router)
+
+        result = await my_task.delay(user_id="42", item=Item(name="x"))  # type: ignore[attr-defined]
+        assert isinstance(result, tasks_v2.Task)
+        request = client.create_task.await_args.kwargs["request"]
+        assert request.task.http_request.url == f"{BASE_URL}/task/42"
+
+        # .options returns a fresh AsyncDelayer with overrides applied
+        delayer = my_task.options(countdown=30)  # type: ignore[attr-defined]
+        assert isinstance(delayer, AsyncDelayer)
+        assert delayer.countdown == 30

--- a/tests/test_async_delayer.py
+++ b/tests/test_async_delayer.py
@@ -51,11 +51,7 @@ def _mock_async_client() -> MagicMock:
 
 
 def _make_delayer(client: Any, *, auto_create_queue: bool = False, **kwargs: Any) -> AsyncDelayer:
-    provider = AsyncCloudTasksClientProvider(
-        client=client,
-        queue_path=QUEUE_PATH,
-        auto_create_queue=auto_create_queue,
-    )
+    provider = AsyncCloudTasksClientProvider(client=client, auto_create_queue=auto_create_queue)
     return AsyncDelayer(
         route=_make_route(),
         base_url=BASE_URL,
@@ -129,7 +125,7 @@ class TestAsyncCloudTasksClientProvider:
         """A client factory should be called once even across concurrent delays."""
         client = _mock_async_client()
         factory = MagicMock(return_value=client)
-        provider = AsyncCloudTasksClientProvider(client=factory, queue_path=QUEUE_PATH)
+        provider = AsyncCloudTasksClientProvider(client=factory)
 
         results = await asyncio.gather(*(provider.get() for _ in range(10)))
 
@@ -139,7 +135,7 @@ class TestAsyncCloudTasksClientProvider:
     async def test_client_instance_used_as_is(self) -> None:
         """A client instance should be returned unchanged."""
         client = _mock_async_client()
-        provider = AsyncCloudTasksClientProvider(client=client, queue_path=QUEUE_PATH)
+        provider = AsyncCloudTasksClientProvider(client=client)
 
         assert await provider.get() is client
 
@@ -179,16 +175,30 @@ class TestAsyncCloudTasksClientProvider:
         factory.assert_called_once()
         assert client.create_queue.await_count == 2
 
+    async def test_auto_create_queue_ensures_overridden_queue_path(self) -> None:
+        """Each distinct queue path used through the provider should be ensured once."""
+        client = _mock_async_client()
+        provider = AsyncCloudTasksClientProvider(client=client, auto_create_queue=True)
+        other_queue = "projects/test-project/locations/us-central1/queues/other-queue"
+
+        await provider.get_for_queue(queue_path=QUEUE_PATH)
+        await provider.get_for_queue(queue_path=other_queue)
+        await provider.get_for_queue(queue_path=other_queue)
+
+        assert client.create_queue.await_count == 2
+        ensured = {call.kwargs["request"].queue.name for call in client.create_queue.await_args_list}
+        assert ensured == {QUEUE_PATH, other_queue}
+
     async def test_wrong_client_type_raises_clear_error(self) -> None:
         """A non-async, non-factory client should fail with a descriptive TypeError."""
-        provider = AsyncCloudTasksClientProvider(client=object(), queue_path=QUEUE_PATH)  # type: ignore[arg-type]
+        provider = AsyncCloudTasksClientProvider(client=object())  # type: ignore[arg-type]
 
         with pytest.raises(TypeError, match="CloudTasksAsyncClient"):
             await provider.get()
 
     async def test_factory_returning_wrong_type_raises_clear_error(self) -> None:
         """A factory that returns the wrong type should fail with a descriptive TypeError."""
-        provider = AsyncCloudTasksClientProvider(client=lambda: None, queue_path=QUEUE_PATH)  # type: ignore[arg-type,return-value]
+        provider = AsyncCloudTasksClientProvider(client=lambda: None)  # type: ignore[arg-type,return-value]
 
         with pytest.raises(TypeError, match="factory must return a CloudTasksAsyncClient"):
             await provider.get()

--- a/tests/test_async_delayer.py
+++ b/tests/test_async_delayer.py
@@ -186,6 +186,13 @@ class TestAsyncCloudTasksClientProvider:
         with pytest.raises(TypeError, match="CloudTasksAsyncClient"):
             await provider.get()
 
+    async def test_factory_returning_wrong_type_raises_clear_error(self) -> None:
+        """A factory that returns the wrong type should fail with a descriptive TypeError."""
+        provider = AsyncCloudTasksClientProvider(client=lambda: None, queue_path=QUEUE_PATH)  # type: ignore[arg-type,return-value]
+
+        with pytest.raises(TypeError, match="factory must return a CloudTasksAsyncClient"):
+            await provider.get()
+
 
 class TestAsyncDelayedRouteBuilder:
     """Tests for the route builder wiring."""

--- a/tests/test_async_scheduler.py
+++ b/tests/test_async_scheduler.py
@@ -1,0 +1,179 @@
+"""Unit tests for AsyncScheduler using mocked async clients."""
+
+# Standard Library Imports
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+# Third Party Imports
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute
+from google.api_core.exceptions import NotFound
+from google.cloud import scheduler_v1
+
+# Imports from this repository
+from fastapi_gcp_tasks.async_clients import AsyncClientProvider
+from fastapi_gcp_tasks.async_scheduled_route import AsyncScheduledRouteBuilder
+from fastapi_gcp_tasks.async_scheduler import AsyncScheduler
+from fastapi_gcp_tasks.hooks import noop_hook
+from fastapi_gcp_tasks.scheduler import Scheduler
+
+LOCATION_PATH = "projects/test-project/locations/us-central1"
+BASE_URL = "http://localhost"
+
+
+def _make_route() -> APIRoute:
+    app = FastAPI()
+
+    @app.post("/scheduled_hello")
+    async def scheduled_hello() -> None:
+        """Endpoint under test."""
+
+    for route in app.routes:
+        if isinstance(route, APIRoute) and route.path == "/scheduled_hello":
+            return route
+    raise ValueError("Route not found")
+
+
+def _mock_async_client() -> MagicMock:
+    client = MagicMock(spec=scheduler_v1.CloudSchedulerAsyncClient)
+    client.get_job = AsyncMock(side_effect=NotFound("no job"))
+    client.delete_job = AsyncMock(return_value=None)
+    client.create_job = AsyncMock(return_value=scheduler_v1.Job())
+    return client
+
+
+def _make_scheduler(client: Any, **kwargs: Any) -> AsyncScheduler:
+    provider = AsyncClientProvider(client=client, client_cls=scheduler_v1.CloudSchedulerAsyncClient)
+    return AsyncScheduler(
+        route=_make_route(),
+        base_url=BASE_URL,
+        location_path=LOCATION_PATH,
+        schedule="*/5 * * * *",
+        pre_create_hook=noop_hook,
+        client_provider=provider,
+        name="test-job",
+        **kwargs,
+    )
+
+
+class TestAsyncScheduler:
+    """Tests for AsyncScheduler schedule/delete flows."""
+
+    async def test_schedule_creates_job_when_missing(self) -> None:
+        """A missing job should be (re)created."""
+        client = _mock_async_client()
+        scheduler = _make_scheduler(client)
+
+        await scheduler.schedule()
+
+        client.create_job.assert_awaited_once()
+        request = client.create_job.await_args.kwargs["request"]
+        assert request.parent == LOCATION_PATH
+        assert request.job.name == f"{LOCATION_PATH}/jobs/test-job"
+        assert request.job.schedule == "*/5 * * * *"
+
+    async def test_schedule_skips_unchanged_job(self) -> None:
+        """An identical existing job should not be recreated."""
+        client = _mock_async_client()
+        scheduler = _make_scheduler(client)
+        # Return the exact job we would create (plus a default User-Agent header)
+        existing = scheduler._build_create_job_request(values={}).job
+        existing.http_target.headers["User-Agent"] = "Google-Cloud-Scheduler"
+        client.get_job = AsyncMock(return_value=scheduler_v1.Job(existing))
+
+        await scheduler.schedule()
+
+        client.delete_job.assert_not_awaited()
+        client.create_job.assert_not_awaited()
+
+    async def test_schedule_recreates_changed_job(self) -> None:
+        """A differing existing job should be deleted and recreated."""
+        client = _mock_async_client()
+        scheduler = _make_scheduler(client)
+        client.get_job = AsyncMock(return_value=scheduler_v1.Job(name=scheduler.job_id, schedule="0 0 * * *"))
+
+        await scheduler.schedule()
+
+        client.delete_job.assert_awaited_once()
+        client.create_job.assert_awaited_once()
+
+    async def test_schedule_force_recreates_without_diff(self) -> None:
+        """force=True should skip the diff and always recreate."""
+        client = _mock_async_client()
+        scheduler = _make_scheduler(client, force=True)
+
+        await scheduler.schedule()
+
+        client.get_job.assert_not_awaited()
+        client.delete_job.assert_awaited_once()
+        client.create_job.assert_awaited_once()
+
+    async def test_delete_returns_true_on_success(self) -> None:
+        """delete() should return True when the RPC succeeds."""
+        client = _mock_async_client()
+        scheduler = _make_scheduler(client)
+
+        assert await scheduler.delete() is True
+        client.delete_job.assert_awaited_once_with(name=scheduler.job_id, timeout=scheduler.job_create_timeout)
+
+    async def test_delete_returns_exception_on_failure(self) -> None:
+        """delete() should return the exception when the RPC fails."""
+        client = _mock_async_client()
+        client.delete_job = AsyncMock(side_effect=NotFound("no job"))
+        scheduler = _make_scheduler(client)
+
+        result = await scheduler.delete()
+        assert isinstance(result, NotFound)
+
+    async def test_factory_resolved_lazily_once(self) -> None:
+        """A client factory should only be called on first use, exactly once."""
+        client = _mock_async_client()
+        factory = MagicMock(return_value=client)
+        scheduler = _make_scheduler(factory)
+        factory.assert_not_called()
+
+        await scheduler.schedule()
+        await scheduler.delete()
+
+        factory.assert_called_once()
+
+    async def test_builder_shares_client_across_scheduler_calls(self) -> None:
+        """All schedulers from one builder must reuse the same lazily-resolved client."""
+        client = _mock_async_client()
+        factory = MagicMock(return_value=client)
+        route_class = AsyncScheduledRouteBuilder(
+            base_url=BASE_URL,
+            location_path=LOCATION_PATH,
+            client=factory,
+        )
+        app = FastAPI()
+        router = APIRouter(route_class=route_class)
+
+        @router.post("/job")
+        async def my_job() -> None:
+            """Job endpoint."""
+
+        app.include_router(router)
+
+        await my_job.scheduler(name="job-a", schedule="* * * * *").schedule()  # type: ignore[attr-defined]
+        await my_job.scheduler(name="job-b", schedule="0 0 * * *").schedule()  # type: ignore[attr-defined]
+
+        factory.assert_called_once()
+        assert client.create_job.await_count == 2
+
+    async def test_request_parity_with_sync_scheduler(self) -> None:
+        """The async and sync schedulers should build identical CreateJobRequests."""
+        async_scheduler = _make_scheduler(_mock_async_client())
+        sync_scheduler = Scheduler(
+            route=_make_route(),
+            base_url=BASE_URL,
+            location_path=LOCATION_PATH,
+            schedule="*/5 * * * *",
+            client=MagicMock(spec=scheduler_v1.CloudSchedulerClient),
+            pre_create_hook=noop_hook,
+            name="test-job",
+        )
+
+        assert async_scheduler._build_create_job_request(values={}) == sync_scheduler._build_create_job_request(
+            values={}
+        )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -16,3 +16,16 @@ def test_countdown_task(uvicorn_server: subprocess.Popen, base_url: str) -> None
     """Countdown route should schedule a delayed task."""
     r = requests.get(f"{base_url}/with_countdown", timeout=5)
     assert r.status_code == 200
+
+
+def test_async_basic_task(uvicorn_server: subprocess.Popen, base_url: str) -> None:  # type: ignore[type-arg]
+    """Async basic route should schedule a task via the async client and return a success message."""
+    r = requests.get(f"{base_url}/async_basic", timeout=5)
+    assert r.status_code == 200
+    assert "scheduled" in r.json().get("message", "").lower()
+
+
+def test_async_countdown_task(uvicorn_server: subprocess.Popen, base_url: str) -> None:  # type: ignore[type-arg]
+    """Async countdown route should schedule a delayed task via the async client."""
+    r = requests.get(f"{base_url}/async_with_countdown", timeout=5)
+    assert r.status_code == 200

--- a/uv.lock
+++ b/uv.lock
@@ -271,6 +271,7 @@ dev = [
     { name = "mypy" },
     { name = "pydantic-settings" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "requests" },
     { name = "ruff" },
     { name = "types-protobuf" },
@@ -290,6 +291,7 @@ dev = [
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "ruff", specifier = ">=0.14.0" },
     { name = "types-protobuf", specifier = ">=5.26.0.20240422" },
@@ -780,6 +782,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #12

## Summary

Adds first-class async support so tasks and jobs can be created from async FastAPI handlers without blocking the event loop (the upstream motivation is Adori/fastapi-cloud-tasks#9):

- **`AsyncDelayedRouteBuilder`** — endpoints get an awaitable `.delay()` (and the usual `.options()`), backed by the native `tasks_v2.CloudTasksAsyncClient`.
- **`AsyncScheduledRouteBuilder`** — `.scheduler(...)` returns an `AsyncScheduler` with awaitable `.schedule()` / `.delete()`, backed by `scheduler_v1.CloudSchedulerAsyncClient`.
- **`utils.ensure_queue_async`** — async queue-ensure helper, intended to be awaited once from a FastAPI lifespan.
- **`utils.async_emulator_client`** — async twin of `emulator_client` for local development.

No new runtime dependency: the async clients ship with the existing `google-cloud-tasks` / `google-cloud-scheduler` packages and use the same protobuf request types, so all existing hooks (`oidc_*`, `deadline_*`, `chained_hook`, custom `pre_create_hook`s) work unchanged with both builders.

## Design notes

- **Lazy client resolution.** grpc.aio channels bind to the event loop that is running when they are constructed, so constructing an async client at module import breaks under a different serving loop. The builders instead accept a client instance, a zero-argument factory, or `None`, and resolve it on the first awaited call inside the running loop via a shared `AsyncClientProvider` (one per builder, so all calls reuse a single client/channel). Passing a wrong type (e.g. a sync client) fails with a descriptive `TypeError`.
- **No surprise RPCs in handlers.** Unlike the sync builder, `auto_create_queue` defaults to `False` on the async builder. Opting in ensures the queue lazily exactly once (failed ensures are retried without leaking clients); the recommended pattern is `ensure_queue_async` from the lifespan.
- **Sync path untouched.** `Delayer`/`Scheduler` are refactored into shared `BaseDelayer`/`BaseScheduler` (request building) with public signatures and behavior unchanged; all pre-existing tests pass as-is.

## Testing

- 13 new unit tests (mocked async clients): request parity with the sync builders, lazy factory resolution (exactly once under `asyncio.gather` concurrency), queue-ensure semantics, ensure-failure retry without client recreation, client-type validation, scheduler create/skip-unchanged/recreate/force/delete flows, and builder-level client sharing.
- 2 new emulator smoke tests (`/async_basic`, `/async_with_countdown`) against the example app.
- Manually verified the full round-trip: uvicorn → `await hello_async.delay(...)` → task created on the Cloud Tasks emulator → emulator dispatched back → handler executed.
- `make lint` (ruff + mypy) and `make test` (30 passed) are green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive API surface with GCP RPC paths in request handlers; sync behavior is preserved and covered by parity tests, but misconfigured async clients or queue setup could fail at runtime in production async apps.
> 
> **Overview**
> Adds **async-first route builders** so task and job creation from async FastAPI handlers uses `CloudTasksAsyncClient` / `CloudSchedulerAsyncClient` instead of blocking the event loop on sync gRPC.
> 
> **`AsyncDelayedRouteBuilder`** wires endpoints with awaitable `.delay()` and sync `.options()`, backed by `AsyncDelayer` and `AsyncCloudTasksClientProvider`. **`auto_create_queue` defaults to `False`** (unlike the sync builder); optional lazy ensure or **`ensure_queue_async`** from lifespan is documented. **`AsyncScheduledRouteBuilder`** exposes awaitable `.schedule()` / `.delete()` via `AsyncScheduler`; scheduling must be awaited from lifespan or handlers, not at import time.
> 
> Shared **`AsyncClientProvider`** lazily resolves and caches one async client per builder (instance, factory, or default credentials), with validation and concurrency-safe factory calls. Helpers **`async_emulator_client`** and **`ensure_queue_async`** mirror the sync utils; queue creation logic is factored into **`_create_queue_request`**.
> 
> Sync **`Delayer`** / **`Scheduler`** are split into **`BaseDelayer`** / **`BaseScheduler`** for shared protobuf request building; public sync APIs and behavior stay the same. **`BaseScheduler._job_changed`** now uses `headers.pop("User-Agent", None)` and path helpers no longer require a client instance at init.
> 
> Package exports, README async section, full example routes (`/async_basic`, `/async_with_countdown`), **pytest-asyncio**, and broad unit/smoke tests cover parity with sync builders, lazy clients, and queue-ensure semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce258631cd2b2eed611d16c75c7a9b5936abc7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class async support for Cloud Tasks and Cloud Scheduler so `.delay()`, `.schedule()`, and `.delete()` can be awaited without blocking FastAPI’s event loop. Sync APIs are unchanged; shared base classes keep behavior the same while async clients are resolved lazily and reused per builder.

- **New Features**
  - `AsyncDelayedRouteBuilder` — awaitable `.delay()`/`.options()` using `CloudTasksAsyncClient`; `auto_create_queue` defaults to False. Use `utils.ensure_queue_async` from lifespan, or opt in with `auto_create_queue=True`.
  - `AsyncScheduledRouteBuilder` — `.scheduler(...)` returns an `AsyncScheduler` with awaitable `.schedule()`/`.delete()` using `CloudSchedulerAsyncClient`.
  - Helpers: `utils.ensure_queue_async` (queue ensure), `utils.async_emulator_client` (local emulator).
  - No new runtime deps; async clients are provided by `google-cloud-tasks` and `google-cloud-scheduler`.

- **Bug Fixes**
  - Lazy auto-create now ensures the effective queue path used per call (including overrides); each distinct path is ensured once.
  - `AsyncClientProvider` validates factory return types and raises clear `TypeError`s on misconfiguration.
  - Scheduler job diff uses `headers.pop("User-Agent", None)` to avoid `KeyError` and unnecessary recreates.
  - Type hints: route builder kwargs are `Any` so `.options(...)` calls type-check; README async examples include missing imports.

<sup>Written for commit 0ce258631cd2b2eed611d16c75c7a9b5936abc7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SimplifyJobs/fastapi-gcp-tasks/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

