### PR TITLE
feat(docs): Add MkDocs Material documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,14 @@ jobs:
         run: uv sync --group docs
 
       - name: Build docs
-        run: uv run mkdocs build --strict
+        run: uv run --group docs mkdocs build --strict
+
+      - name: Configure git credentials
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        run: uv run mkdocs gh-deploy --force
+        run: uv run --group docs mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,11 +6,19 @@ on:
   pull_request:
     branches: [ master ]
 
+# Build runs on PR-controlled code, so it only gets read access; the deploy
+# job below is the only one with write scope and only runs on master pushes.
 permissions:
-  contents: write
+  contents: read
+
+# Serialize per ref so a slow run from an older master push can't finish
+# after a newer one and force-push stale site content.
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  docs:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,12 +38,31 @@ jobs:
       - name: Build docs
         run: uv run --group docs mkdocs build --strict
 
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: uv sync --group docs
+
       - name: Configure git credentials
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: uv run --group docs mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: Docs
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: uv sync --group docs
+
+      - name: Build docs
+        run: uv run mkdocs build --strict
+
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: uv run mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,13 +6,14 @@ on:
   pull_request:
     branches: [ master ]
 
-# Build runs on PR-controlled code, so it only gets read access; the deploy
-# job below is the only one with write scope and only runs on master pushes.
+# No job ever needs contents: write — the deploy job publishes the built
+# artifact through the Pages API (pages: write + id-token: write) instead of
+# pushing a gh-pages branch.
 permissions:
   contents: read
 
 # Serialize per ref so a slow run from an older master push can't finish
-# after a newer one and force-push stale site content.
+# after a newer one and publish stale site content.
 concurrency:
   group: docs-${{ github.ref }}
   cancel-in-progress: true
@@ -33,36 +34,31 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: uv sync --group docs
+        run: uv sync --locked --group docs
 
       - name: Build docs
         run: uv run --group docs mkdocs build --strict
 
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+  # Deploys the exact artifact that passed the strict build — no rebuild, no
+  # dependency installation, and no write-scoped token in this job beyond the
+  # Pages deployment itself.
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        run: uv sync --group docs
-
-      - name: Configure git credentials
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
       - name: Deploy to GitHub Pages
-        run: uv run --group docs mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format test
+.PHONY: lint format test docs docs-build
 
 lint:
 	uv run scripts/lint.sh
@@ -8,3 +8,9 @@ format:
 
 test:
 	uv run pytest -q -x -s
+
+docs:
+	uv run --group docs mkdocs serve
+
+docs-build:
+	uv run --group docs mkdocs build --strict

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Strongly typed background tasks with FastAPI and Google Cloud Run, Tasks and Scheduler. This is a fork of [fastapi-gcp-tasks](https://github.com/adori/fastapi-cloud-tasks), updated with new features and bug fixes.
 
+**📚 Documentation: [simplifyjobs.github.io/fastapi-gcp-tasks](https://simplifyjobs.github.io/fastapi-gcp-tasks/)**
+
 ```mermaid
 sequenceDiagram
     autonumber

--- a/docs/api/delayers-and-schedulers.md
+++ b/docs/api/delayers-and-schedulers.md
@@ -1,0 +1,14 @@
+# Delayers & schedulers
+
+These are the objects returned by `.options()` and `.scheduler()` on task endpoints. You rarely construct
+them directly.
+
+::: fastapi_gcp_tasks.delayer
+
+::: fastapi_gcp_tasks.async_delayer
+
+::: fastapi_gcp_tasks.scheduler
+
+::: fastapi_gcp_tasks.async_scheduler
+
+::: fastapi_gcp_tasks.async_clients

--- a/docs/api/dependencies.md
+++ b/docs/api/dependencies.md
@@ -1,0 +1,3 @@
+# Dependencies
+
+::: fastapi_gcp_tasks.dependencies

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -1,0 +1,3 @@
+# Exceptions
+
+::: fastapi_gcp_tasks.exception

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -1,0 +1,3 @@
+# Hooks
+
+::: fastapi_gcp_tasks.hooks

--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -1,0 +1,6 @@
+# Typed protocols
+
+Typed views of task endpoints and the option `TypedDict`s. See the
+[Type safety guide](../guide/type-safety.md) for usage.
+
+::: fastapi_gcp_tasks.protocols

--- a/docs/api/route-builders.md
+++ b/docs/api/route-builders.md
@@ -1,0 +1,14 @@
+# Route builders
+
+The four route builders return an `APIRoute` subclass to pass as `route_class=` to an `APIRouter`. Endpoints
+registered on that router gain `.delay`/`.options` (delayed) or `.scheduler` (scheduled) methods.
+
+::: fastapi_gcp_tasks.delayed_route.DelayedRouteBuilder
+
+::: fastapi_gcp_tasks.async_delayed_route.AsyncDelayedRouteBuilder
+
+::: fastapi_gcp_tasks.scheduled_route.ScheduledRouteBuilder
+
+::: fastapi_gcp_tasks.async_scheduled_route.AsyncScheduledRouteBuilder
+
+::: fastapi_gcp_tasks.decorators.task_default_options

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,3 @@
+# Utilities
+
+::: fastapi_gcp_tasks.utils

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,39 @@
+# Contributing
+
+- Run `make lint` and `make format` before raising a PR.
+- Add examples and/or tests for new features.
+- If the change is massive, open an issue to discuss it before writing code.
+
+## Development setup
+
+Prerequisites:
+
+- [uv](https://docs.astral.sh/uv/)
+- Docker (for the Cloud Tasks emulator)
+
+### Running tests
+
+```sh
+docker compose up -d       # start emulator
+make test                  # run tests
+docker compose down        # stop emulator
+```
+
+### Linting & formatting
+
+```sh
+make lint                  # mypy strict + ruff check
+make format                # auto-fix
+```
+
+### Docs
+
+```sh
+make docs                  # live-reloading docs server
+make docs-build            # strict build (what CI runs)
+```
+
+The docs live in `docs/` and are built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/);
+the API reference is generated from source docstrings with
+[mkdocstrings](https://mkdocstrings.github.io/). They deploy to GitHub Pages automatically on every push to
+`master`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -36,4 +36,4 @@ make docs-build            # strict build (what CI runs)
 The docs live in `docs/` and are built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/);
 the API reference is generated from source docstrings with
 [mkdocstrings](https://mkdocstrings.github.io/). They deploy to GitHub Pages automatically on every push to
-`master`.
+`master` via the Pages artifact flow (repo setting: Settings → Pages → Source → GitHub Actions).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,107 @@
+# Getting started
+
+## Installation
+
+```sh
+pip install fastapi-gcp-tasks
+```
+
+Python 3.11+ is required.
+
+## Your first delayed task
+
+A delayed task is a plain FastAPI endpoint registered on a router whose `route_class` comes from
+`DelayedRouteBuilder`. That gives the endpoint a `.delay()` method:
+
+```python
+import os
+
+from fastapi import FastAPI
+from fastapi.routing import APIRouter
+from pydantic import BaseModel
+
+from fastapi_gcp_tasks import DelayedRouteBuilder, as_delayed_task
+from fastapi_gcp_tasks.utils import emulator_client, queue_path
+
+IS_LOCAL = os.getenv("IS_LOCAL", "true").lower() == "true"
+
+# For local development, point the client at the emulator
+client = emulator_client() if IS_LOCAL else None
+
+DelayedRoute = DelayedRouteBuilder(
+    client=client,
+    # Base URL where the task server is hosted
+    base_url="http://localhost:8000",
+    # Full queue path where tasks will be sent
+    queue_path=queue_path(
+        project="gcp-project-id",
+        location="us-central1",
+        queue="test-queue",
+    ),
+)
+
+delayed_router = APIRouter(route_class=DelayedRoute, prefix="/delayed")
+
+
+class Payload(BaseModel):
+    message: str
+
+
+@delayed_router.post("/hello")
+@as_delayed_task  # optional: makes .delay statically visible to type checkers
+async def hello(p: Payload = Payload(message="Default")) -> None:
+    print(f"Hello task ran with payload: {p.message}")
+
+
+app = FastAPI()
+
+
+@app.get("/trigger")
+async def trigger() -> dict[str, str]:
+    hello.delay(p=Payload(message="Triggered task"))
+    return {"message": "Hello task triggered"}
+
+
+app.include_router(delayed_router)
+```
+
+## Running locally
+
+There is no local Cloud Tasks service, so use the open-source
+[cloud-tasks-emulator](https://github.com/aertje/cloud-tasks-emulator) (alternatively, install ngrok and
+forward the server's port to use the real Cloud Tasks).
+
+Start the emulator in one terminal:
+
+```sh
+cloud-tasks-emulator
+```
+
+Start the app on port 8000 so Cloud Tasks can reach it:
+
+```sh
+uvicorn examples.simple.main:app --reload --port 8000
+```
+
+Trigger the task from another terminal:
+
+```sh
+curl http://localhost:8000/trigger
+```
+
+Check the server logs — you should see:
+
+```
+WARNING:  Hello task ran with payload: Triggered task
+```
+
+The complete working example lives at
+[`examples/simple/main.py`](https://github.com/SimplifyJobs/fastapi-gcp-tasks/blob/master/examples/simple/main.py).
+In the real world you'd run the task worker as a separate process from the service that triggers tasks.
+
+## Next steps
+
+- [Delayed tasks](guide/delayed-tasks.md) — countdowns, deduplication, and per-call overrides.
+- [Scheduled tasks](guide/scheduled-tasks.md) — recurring jobs on a cron schedule.
+- [Async usage](guide/async.md) — `await .delay()` without blocking the event loop.
+- [Deploying to Cloud Run](guide/deployment.md) — OIDC auth with hooks.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,7 @@ A delayed task is a plain FastAPI endpoint registered on a router whose `route_c
 `DelayedRouteBuilder`. That gives the endpoint a `.delay()` method:
 
 ```python
+import logging
 import os
 
 from fastapi import FastAPI
@@ -42,6 +43,8 @@ DelayedRoute = DelayedRouteBuilder(
 
 delayed_router = APIRouter(route_class=DelayedRoute, prefix="/delayed")
 
+logger = logging.getLogger("uvicorn")
+
 
 class Payload(BaseModel):
     message: str
@@ -50,14 +53,16 @@ class Payload(BaseModel):
 @delayed_router.post("/hello")
 @as_delayed_task  # optional: makes .delay statically visible to type checkers
 async def hello(p: Payload = Payload(message="Default")) -> None:
-    print(f"Hello task ran with payload: {p.message}")
+    logger.warning(f"Hello task ran with payload: {p.message}")
 
 
 app = FastAPI()
 
 
+# A plain `def` endpoint: the sync `.delay()` makes a blocking gRPC call, so let
+# FastAPI run it in the threadpool (or see the Async usage guide for `await .delay()`).
 @app.get("/trigger")
-async def trigger() -> dict[str, str]:
+def trigger() -> dict[str, str]:
     hello.delay(p=Payload(message="Triggered task"))
     return {"message": "Hello task triggered"}
 
@@ -77,11 +82,14 @@ Start the emulator in one terminal:
 cloud-tasks-emulator
 ```
 
-Start the app on port 8000 so Cloud Tasks can reach it:
+Save the snippet as `main.py` and start it on port 8000 so Cloud Tasks can reach it:
 
 ```sh
-uvicorn examples.simple.main:app --reload --port 8000
+uvicorn main:app --reload --port 8000
 ```
+
+(If you cloned the repository instead, the checked-in example runs with
+`uvicorn examples.simple.main:app --reload --port 8000`.)
 
 Trigger the task from another terminal:
 

--- a/docs/guide/async.md
+++ b/docs/guide/async.md
@@ -10,16 +10,16 @@ from fastapi_gcp_tasks import AsyncDelayedRouteBuilder, as_async_delayed_task
 async_delayed_router = APIRouter(route_class=AsyncDelayedRouteBuilder(...))
 
 
-@async_delayed_router.post("/{restaurant}/make_dinner")
+@async_delayed_router.post("/{branch}/make_chili")
 @as_async_delayed_task
-async def make_dinner(restaurant: str, recipe: Recipe) -> None: ...
+async def make_chili(branch: str, recipe: Recipe) -> None: ...
 
 
 app.include_router(async_delayed_router)
 
 # In an async context (endpoint, lifespan, etc):
-await make_dinner.delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))
-await make_dinner.options(countdown=1800).delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))
+await make_chili.delay(branch="Scranton", recipe=Recipe(ingredients=["Ground beef", "Undercooked onions"]))
+await make_chili.options(countdown=1800).delay(branch="Scranton", recipe=Recipe(ingredients=["Ground beef", "Undercooked onions"]))
 ```
 
 Similarly, `AsyncScheduledRouteBuilder` provides awaitable `.schedule()` and `.delete()` — useful when
@@ -34,18 +34,18 @@ from fastapi_gcp_tasks import AsyncScheduledRouteBuilder, as_async_scheduled_tas
 async_scheduled_router = APIRouter(route_class=AsyncScheduledRouteBuilder(...))
 
 
-@async_scheduled_router.post("/home_cook")
+@async_scheduled_router.post("/pretzel_day")
 @as_async_scheduled_task
-async def home_cook(recipe: Recipe) -> None: ...
+async def pretzel_day(recipe: Recipe) -> None: ...
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    await home_cook.scheduler(
-        name="home-cook-7AM-IST",
-        schedule="0 7 * * *",
-        time_zone="Asia/Kolkata",
-    ).schedule(recipe=Recipe(ingredients=["Milk", "Cereal"]))
+    await pretzel_day.scheduler(
+        name="pretzel-day-9AM-scranton",
+        schedule="0 9 * * 5",
+        time_zone="America/New_York",
+    ).schedule(recipe=Recipe(ingredients=["Sweet glaze", "Cinnamon sugar"]))
     yield
 ```
 

--- a/docs/guide/async.md
+++ b/docs/guide/async.md
@@ -1,0 +1,86 @@
+# Async usage
+
+`DelayedRouteBuilder`'s `.delay()` makes a blocking gRPC call. Called from an async endpoint, it stalls the
+event loop until Cloud Tasks responds. `AsyncDelayedRouteBuilder` uses the native `CloudTasksAsyncClient`
+instead, so triggering a task is a proper coroutine:
+
+```python
+from fastapi_gcp_tasks import AsyncDelayedRouteBuilder, as_async_delayed_task
+
+async_delayed_router = APIRouter(route_class=AsyncDelayedRouteBuilder(...))
+
+
+@async_delayed_router.post("/{restaurant}/make_dinner")
+@as_async_delayed_task
+async def make_dinner(restaurant: str, recipe: Recipe) -> None: ...
+
+
+app.include_router(async_delayed_router)
+
+# In an async context (endpoint, lifespan, etc):
+await make_dinner.delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))
+await make_dinner.options(countdown=1800).delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))
+```
+
+Similarly, `AsyncScheduledRouteBuilder` provides awaitable `.schedule()` and `.delete()` — useful when
+creating Cloud Scheduler jobs dynamically from request handlers. Since it can't run at module import time
+like the sync version, await it from a lifespan (or a handler):
+
+```python
+from contextlib import asynccontextmanager
+
+from fastapi_gcp_tasks import AsyncScheduledRouteBuilder, as_async_scheduled_task
+
+async_scheduled_router = APIRouter(route_class=AsyncScheduledRouteBuilder(...))
+
+
+@async_scheduled_router.post("/home_cook")
+@as_async_scheduled_task
+async def home_cook(recipe: Recipe) -> None: ...
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await home_cook.scheduler(
+        name="home-cook-7AM-IST",
+        schedule="0 7 * * *",
+        time_zone="Asia/Kolkata",
+    ).schedule(recipe=Recipe(ingredients=["Milk", "Cereal"]))
+    yield
+```
+
+## Things to know about the async builders
+
+### The client is created lazily
+
+grpc.aio clients bind to the event loop that is running when they are constructed, so the builder resolves
+its client on the first awaited call, inside your app's loop. `client` accepts a client instance, a
+zero-argument factory returning one, or `None` (default credentials). If your client needs custom
+construction — like the local emulator — pass a factory:
+
+```python
+client = lambda: async_emulator_client()
+```
+
+### The queue is not auto-created by default
+
+Unlike `DelayedRouteBuilder`, `auto_create_queue` defaults to `False` so no unexpected RPC runs inside a
+request handler. Either ensure the queue from your lifespan with the `ensure_queue_async` util
+(recommended), or opt in with `auto_create_queue=True` to ensure it lazily on the first `.delay()`:
+
+```python
+from contextlib import asynccontextmanager
+
+from fastapi_gcp_tasks.utils import ensure_queue_async
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await ensure_queue_async(client=my_async_client, path=MY_QUEUE_PATH)
+    yield
+```
+
+### Hooks are unchanged
+
+The same (synchronous) `pre_create_hook`s work with both sync and async builders — they are pure in-memory
+mutations of the request proto and run inline on the event loop, so they must not block.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,0 +1,95 @@
+# Configuration
+
+## DelayedRouteBuilder
+
+```python
+DelayedRoute = DelayedRouteBuilder(...)
+delayed_router = APIRouter(route_class=DelayedRoute)
+
+
+@delayed_router.get("/simple_task")
+def simple_task() -> None: ...
+```
+
+| Option | Description |
+| --- | --- |
+| `base_url` | The URL of your worker FastAPI service. |
+| `queue_path` | Full path of the Cloud Tasks queue. (Hint: use the [`queue_path`](../api/utils.md) util.) |
+| `task_create_timeout` | How long to wait before giving up on creating the cloud task. Default `10.0` seconds. |
+| `pre_create_hook` | Edit the `CreateTaskRequest` before it is sent (e.g. auth for Cloud Run). See [Hooks](hooks-and-dependencies.md). |
+| `client` | Override the `CloudTasksClient` (e.g. custom credentials or transport, the emulator). |
+| `auto_create_queue` | Ensure the queue exists at builder creation time. Default `True`. |
+
+### Task-level default options
+
+All `Delayer` options can be set per-endpoint with the `task_default_options` decorator:
+
+```python
+from fastapi_gcp_tasks import task_default_options
+
+
+# Trigger after 5 minutes
+@delayed_router.get("/simple_task")
+@task_default_options(countdown=300)
+def simple_task() -> None: ...
+```
+
+Additional options beyond the builder options:
+
+| Option | Description |
+| --- | --- |
+| `countdown` | Seconds in the future to schedule the task. |
+| `task_id` | Named task id for deduplication. (One task id will only be queued once.) |
+
+### Per-call options
+
+Everything above can be overridden per call (including builder options like `base_url`) with `.options()`
+before calling `.delay()`:
+
+```python
+# Trigger after 2 minutes
+simple_task.options(countdown=120).delay()
+```
+
+The accepted keys are typed as the [`DelayOptions` TypedDict](../api/protocols.md).
+
+## AsyncDelayedRouteBuilder
+
+Same options as `DelayedRouteBuilder`, with two differences:
+
+| Option | Description |
+| --- | --- |
+| `client` | A `CloudTasksAsyncClient`, a zero-argument factory returning one, or `None`. Resolved lazily on the first awaited `.delay()` because grpc.aio clients bind to the running event loop. |
+| `auto_create_queue` | Defaults to `False` (the sync builder defaults to `True`). When `True`, the queue is ensured lazily on the first `.delay()`. Prefer calling `ensure_queue_async` from your lifespan instead. |
+
+## ScheduledRouteBuilder
+
+```python
+ScheduledRoute = ScheduledRouteBuilder(...)
+scheduled_router = APIRouter(route_class=ScheduledRoute)
+
+
+@scheduled_router.get("/simple_scheduled_task")
+def simple_scheduled_task() -> None: ...
+
+
+simple_scheduled_task.scheduler(name="simple_scheduled_task", schedule="* * * * *").schedule()
+```
+
+| Option | Description |
+| --- | --- |
+| `base_url` | The URL of your worker FastAPI service. |
+| `location_path` | Full location path for Cloud Scheduler. (Hint: use the [`location_path`](../api/utils.md) util.) |
+| `job_create_timeout` | How long to wait before giving up on creating the job. Default `10.0` seconds. |
+| `pre_create_hook` | Edit the `CreateJobRequest` before it is sent. See [Hooks](hooks-and-dependencies.md). |
+| `client` | Override the `CloudSchedulerClient`. |
+
+`.scheduler(...)` accepts `name` and `schedule` (cron expression) as required keywords, plus per-call
+overrides typed as the [`SchedulerOptions` TypedDict](../api/protocols.md): `time_zone` (default `"UTC"`),
+`retry_config`, `force`, and the builder options above.
+
+## AsyncScheduledRouteBuilder
+
+Same options as `ScheduledRouteBuilder`, except `client` accepts a `CloudSchedulerAsyncClient`, a
+zero-argument factory returning one, or `None` (resolved lazily, as above). `.schedule()` and `.delete()`
+are coroutines — await them from a lifespan or a request handler.

--- a/docs/guide/delayed-tasks.md
+++ b/docs/guide/delayed-tasks.md
@@ -15,10 +15,10 @@ class Recipe(BaseModel):
     ingredients: list[str]
 
 
-@delayed_router.post("/{restaurant}/make_dinner")
+@delayed_router.post("/{branch}/make_chili")
 @as_delayed_task
-async def make_dinner(restaurant: str, recipe: Recipe) -> None:
-    # Do a ton of work here.
+async def make_chili(branch: str, recipe: Recipe) -> None:
+    # Do a ton of work here. The secret is to undercook the onions.
     ...
 
 
@@ -31,7 +31,7 @@ Pydantic bodies, `Depends`, middlewares, and telemetry.
 ## Triggering
 
 ```python
-make_dinner.delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))
+make_chili.delay(branch="Scranton", recipe=Recipe(ingredients=["Ground beef", "Undercooked onions"]))
 ```
 
 `.delay()` takes the same (keyword) arguments as the endpoint, validates them, builds the full task URL, and
@@ -41,7 +41,7 @@ HTTP status matters (2xx acknowledges the task; anything else retries it).
 To trigger 30 minutes later:
 
 ```python
-make_dinner.options(countdown=1800).delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))
+make_chili.options(countdown=1800).delay(branch="Scranton", recipe=Recipe(ingredients=["Ground beef", "Undercooked onions"]))
 ```
 
 ## Per-endpoint defaults
@@ -63,7 +63,7 @@ def simple_task() -> None: ...
 Pass a `task_id` to make Cloud Tasks queue a given task at most once:
 
 ```python
-make_dinner.options(task_id=f"dinner-{order_id}").delay(...)
+make_chili.options(task_id=f"chili-{party_id}").delay(...)
 ```
 
 !!! note

--- a/docs/guide/delayed-tasks.md
+++ b/docs/guide/delayed-tasks.md
@@ -1,0 +1,79 @@
+# Delayed tasks
+
+Delayed tasks are the Cloud Tasks half of the library: trigger any FastAPI endpoint later, with retries
+managed by the queue.
+
+## Defining a task
+
+```python
+from fastapi_gcp_tasks import DelayedRouteBuilder, as_delayed_task
+
+delayed_router = APIRouter(route_class=DelayedRouteBuilder(...))
+
+
+class Recipe(BaseModel):
+    ingredients: list[str]
+
+
+@delayed_router.post("/{restaurant}/make_dinner")
+@as_delayed_task
+async def make_dinner(restaurant: str, recipe: Recipe) -> None:
+    # Do a ton of work here.
+    ...
+
+
+app.include_router(delayed_router)
+```
+
+Because the task is a FastAPI endpoint, everything FastAPI offers works: path/query/header parameters,
+Pydantic bodies, `Depends`, middlewares, and telemetry.
+
+## Triggering
+
+```python
+make_dinner.delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))
+```
+
+`.delay()` takes the same (keyword) arguments as the endpoint, validates them, builds the full task URL, and
+creates the task on Cloud Tasks. The return value of the endpoint is meaningless to the queue — only the
+HTTP status matters (2xx acknowledges the task; anything else retries it).
+
+To trigger 30 minutes later:
+
+```python
+make_dinner.options(countdown=1800).delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))
+```
+
+## Per-endpoint defaults
+
+Set default options once with the `task_default_options` decorator instead of at every call site:
+
+```python
+from fastapi_gcp_tasks import task_default_options
+
+
+# Trigger after 5 minutes by default
+@delayed_router.get("/simple_task")
+@task_default_options(countdown=300)
+def simple_task() -> None: ...
+```
+
+## Deduplication
+
+Pass a `task_id` to make Cloud Tasks queue a given task at most once:
+
+```python
+make_dinner.options(task_id=f"dinner-{order_id}").delay(...)
+```
+
+!!! note
+    Named task deduplication is not supported by the local emulator, and Cloud Tasks raises
+    `google.api_core.exceptions.AlreadyExists` when a task id is reused.
+
+## Retries
+
+Cloud Tasks retries a task until it responds with a 2xx status. To cap retries from the worker side, use the
+[`max_retries` dependency](hooks-and-dependencies.md#max_retries).
+
+See [Configuration](configuration.md) for every option accepted by `DelayedRouteBuilder`, `.options()`, and
+`task_default_options`.

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -1,0 +1,45 @@
+# Deploying to Cloud Run
+
+Running on Cloud Run with authentication needs us to supply an OIDC token. To do that we can use a
+[hook](hooks-and-dependencies.md).
+
+Pre-requisites:
+
+- Create a task queue. Copy the project id, location, and queue name.
+- Deploy the worker as a service on Cloud Run and copy its URL.
+- Create a service account in Cloud IAM and add the `Cloud Run Invoker` role to it.
+
+```python
+from google.cloud import tasks_v2
+
+from fastapi_gcp_tasks import DelayedRouteBuilder
+from fastapi_gcp_tasks.hooks import oidc_delayed_hook
+from fastapi_gcp_tasks.utils import queue_path
+
+# URL of the Cloud Run service
+base_url = "https://hello-randomchars-el.a.run.app"
+
+DelayedRoute = DelayedRouteBuilder(
+    base_url=base_url,
+    queue_path=queue_path(...),
+    pre_create_hook=oidc_delayed_hook(
+        token=tasks_v2.OidcToken(
+            # Service account that you created
+            service_account_email="fastapi-gcp-tasks@gcp-project-id.iam.gserviceaccount.com",
+            audience=base_url,
+        ),
+    ),
+)
+```
+
+Check the fleshed-out example at
+[`examples/full/tasks.py`](https://github.com/SimplifyJobs/fastapi-gcp-tasks/blob/master/examples/full/tasks.py) —
+it chains OIDC auth with a worker deadline, wires up the async builders, and schedules a recurring job.
+
+If you're not running on Cloud Run and want an OAuth token instead, use `oauth_delayed_hook` /
+`oauth_scheduled_hook`.
+
+!!! tip "Autoscaling"
+    With Cloud Run, your task workers autoscale based on load — and scale to zero when idle. Pair this with
+    Cloud Tasks' generous free tier and the setup is usually far cheaper than an always-on celery worker and
+    broker.

--- a/docs/guide/hooks-and-dependencies.md
+++ b/docs/guide/hooks-and-dependencies.md
@@ -1,0 +1,75 @@
+# Hooks & dependencies
+
+## Hooks
+
+We might need to override things in the task being sent to Cloud Tasks or Cloud Scheduler. The
+`pre_create_hook` on every route builder allows that: it receives the `CreateTaskRequest` /
+`CreateJobRequest` proto just before it is sent and returns the (possibly modified) request.
+
+Hooks included in the library:
+
+- `oidc_delayed_hook` / `oidc_scheduled_hook` — attach an OIDC token (for Cloud Run etc).
+- `oauth_delayed_hook` / `oauth_scheduled_hook` — attach an OAuth token (for non-Cloud Run targets).
+- `deadline_delayed_hook` / `deadline_scheduled_hook` — change the timeout for the worker of a task.
+  (This deadline is decided by the sender, not the worker.)
+- `chained_hook` — compose multiple hooks: `chained_hook(hook1, hook2)`.
+
+```python
+from google.protobuf import duration_pb2
+
+from fastapi_gcp_tasks.hooks import chained_hook, deadline_delayed_hook, oidc_delayed_hook
+
+DelayedRoute = DelayedRouteBuilder(
+    ...,
+    pre_create_hook=chained_hook(
+        # Add service account auth for Cloud Run
+        oidc_delayed_hook(token=tasks_v2.OidcToken(...)),
+        # Give the worker half an hour
+        deadline_delayed_hook(duration=duration_pb2.Duration(seconds=1800)),
+    ),
+)
+```
+
+Writing your own hook is just writing a function:
+
+```python
+def my_hook(request: tasks_v2.CreateTaskRequest) -> tasks_v2.CreateTaskRequest:
+    request.task.http_request.headers["x-my-header"] = "value"
+    return request
+```
+
+Hooks are synchronous and shared between the sync and async builders. They run inline (on the event loop for
+the async builders), so they must not block.
+
+## Helper dependencies
+
+### max_retries
+
+Cloud Tasks retries a task until it gets a 2xx response. `max_retries` gives up after N attempts by
+responding with a 200 status once the retry count is exhausted:
+
+```python
+from fastapi_gcp_tasks import max_retries
+
+
+@delayed_router.post("/fail_twice", dependencies=[Depends(max_retries(2))])
+async def fail_twice() -> None:
+    raise Exception("nooo")
+```
+
+### CloudTasksHeaders
+
+Typed access to the
+[headers Cloud Tasks sends to your worker](https://cloud.google.com/tasks/docs/creating-http-target-tasks#handler)
+(retry count, queue name, task name, eta, ...):
+
+```python
+from fastapi_gcp_tasks import CloudTasksHeaders
+
+
+@delayed_router.get("/my_task")
+async def my_task(ct_headers: CloudTasksHeaders = Depends()) -> None:
+    print(ct_headers.queue_name)
+```
+
+See the [Dependencies API reference](../api/dependencies.md) for all fields.

--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -15,21 +15,21 @@ class Recipe(BaseModel):
     ingredients: list[str]
 
 
-@scheduled_router.post("/home_cook")
+@scheduled_router.post("/pretzel_day")
 @as_scheduled_task
-async def home_cook(recipe: Recipe) -> None:
-    # Make my own food
+async def pretzel_day(recipe: Recipe) -> None:
+    # Everyone gets one free soft pretzel
     ...
 
 
 app.include_router(scheduled_router)
 
-# Make my own breakfast every morning at 7AM IST.
-home_cook.scheduler(
-    name="test-home-cook-at-7AM-IST",
-    schedule="0 7 * * *",
-    time_zone="Asia/Kolkata",
-).schedule(recipe=Recipe(ingredients=["Milk", "Cereal"]))
+# Every Friday at 9AM in Scranton, it's Pretzel Day.
+pretzel_day.scheduler(
+    name="pretzel-day-9AM-scranton",
+    schedule="0 9 * * 5",
+    time_zone="America/New_York",
+).schedule(recipe=Recipe(ingredients=["Sweet glaze", "Cinnamon sugar"]))
 ```
 
 `.scheduler(...)` configures the job (name, cron schedule, time zone, retry config); `.schedule(...)` takes
@@ -44,7 +44,7 @@ instances. Pass `force=True` to always recreate.
 ## Deleting a job
 
 ```python
-home_cook.scheduler(name="test-home-cook-at-7AM-IST", schedule="0 7 * * *").delete()
+pretzel_day.scheduler(name="pretzel-day-9AM-scranton", schedule="0 9 * * 5").delete()
 ```
 
 See [Configuration](configuration.md#scheduledroutebuilder) for all options, and

--- a/docs/guide/scheduled-tasks.md
+++ b/docs/guide/scheduled-tasks.md
@@ -1,0 +1,51 @@
+# Scheduled tasks
+
+Scheduled tasks are the Cloud Scheduler half of the library: run any FastAPI endpoint on a cron schedule —
+a replacement for celery beat.
+
+## Defining and scheduling
+
+```python
+from fastapi_gcp_tasks import ScheduledRouteBuilder, as_scheduled_task
+
+scheduled_router = APIRouter(route_class=ScheduledRouteBuilder(...))
+
+
+class Recipe(BaseModel):
+    ingredients: list[str]
+
+
+@scheduled_router.post("/home_cook")
+@as_scheduled_task
+async def home_cook(recipe: Recipe) -> None:
+    # Make my own food
+    ...
+
+
+app.include_router(scheduled_router)
+
+# Make my own breakfast every morning at 7AM IST.
+home_cook.scheduler(
+    name="test-home-cook-at-7AM-IST",
+    schedule="0 7 * * *",
+    time_zone="Asia/Kolkata",
+).schedule(recipe=Recipe(ingredients=["Milk", "Cereal"]))
+```
+
+`.scheduler(...)` configures the job (name, cron schedule, time zone, retry config); `.schedule(...)` takes
+the endpoint's own keyword arguments, which become the job's HTTP body/params.
+
+## Idempotent job creation
+
+`.schedule()` compares the job it is about to create against the existing job with the same name and only
+recreates it when something changed, so it is safe to call at startup on every deploy and from multiple
+instances. Pass `force=True` to always recreate.
+
+## Deleting a job
+
+```python
+home_cook.scheduler(name="test-home-cook-at-7AM-IST", schedule="0 7 * * *").delete()
+```
+
+See [Configuration](configuration.md#scheduledroutebuilder) for all options, and
+[Async usage](async.md) for `AsyncScheduledRouteBuilder`, whose `.schedule()`/`.delete()` are coroutines.

--- a/docs/guide/type-safety.md
+++ b/docs/guide/type-safety.md
@@ -25,15 +25,15 @@ Add one of the `as_*_task` decorators as the **innermost** decorator. They are i
 from fastapi_gcp_tasks import as_delayed_task
 
 
-@delayed_router.post("/{restaurant}/make_dinner")
+@delayed_router.post("/{branch}/make_chili")
 @as_delayed_task
-async def make_dinner(restaurant: str, recipe: Recipe) -> None: ...
+async def make_chili(branch: str, recipe: Recipe) -> None: ...
 
 
-make_dinner.delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))  # statically checked
-make_dinner.delay(restaurant="Taj", recipe="oops")  # type error: wrong type for "recipe"
-make_dinner.delay(restaurant="Taj")                 # type error: missing "recipe"
-make_dinner.options(countdown=1800).delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))
+make_chili.delay(branch="Scranton", recipe=Recipe(ingredients=["Ground beef", "Undercooked onions"]))  # statically checked
+make_chili.delay(branch="Scranton", recipe="oops")  # type error: wrong type for "recipe"
+make_chili.delay(branch="Scranton")                 # type error: missing "recipe"
+make_chili.options(countdown=1800).delay(branch="Scranton", recipe=Recipe(ingredients=["Ground beef", "Undercooked onions"]))
 ```
 
 Each route builder has a matching decorator:
@@ -52,8 +52,8 @@ Options accepted by `.options()`, `.scheduler()`, and `task_default_options` are
 misspelled or wrongly-typed options are caught statically too:
 
 ```python
-make_dinner.options(countdown="soon")  # type error: countdown expects int
-make_dinner.options(countdwn=60)       # type error: unknown option
+make_chili.options(countdown="soon")  # type error: countdown expects int
+make_chili.options(countdwn=60)       # type error: unknown option
 ```
 
 ## Caveats

--- a/docs/guide/type-safety.md
+++ b/docs/guide/type-safety.md
@@ -1,0 +1,67 @@
+# Type safety
+
+The package ships a `py.typed` marker (PEP 561), so mypy and pyright check everything you import from it.
+
+## The problem with `.delay`
+
+`.delay`, `.options`, and `.scheduler` are attached to your endpoint function at route registration time.
+A plain function annotation can't express that, so out of the box a type checker rejects the call:
+
+```python
+@delayed_router.post("/hello")
+async def hello(p: Payload) -> None: ...
+
+hello.delay(p=Payload(message="hi"))
+# error: "Callable[[Payload], Coroutine[Any, Any, None]]" has no attribute "delay"
+```
+
+## The `as_*_task` decorators
+
+Add one of the `as_*_task` decorators as the **innermost** decorator. They are identity functions at runtime
+(zero overhead) and cast the endpoint to a `Protocol` that carries the endpoint's own signature via
+`ParamSpec`:
+
+```python
+from fastapi_gcp_tasks import as_delayed_task
+
+
+@delayed_router.post("/{restaurant}/make_dinner")
+@as_delayed_task
+async def make_dinner(restaurant: str, recipe: Recipe) -> None: ...
+
+
+make_dinner.delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))  # statically checked
+make_dinner.delay(restaurant="Taj", recipe="oops")  # type error: wrong type for "recipe"
+make_dinner.delay(restaurant="Taj")                 # type error: missing "recipe"
+make_dinner.options(countdown=1800).delay(restaurant="Taj", recipe=Recipe(ingredients=["Pav", "Bhaji"]))
+```
+
+Each route builder has a matching decorator:
+
+| Route builder | Decorator | Typed protocol |
+| --- | --- | --- |
+| `DelayedRouteBuilder` | `as_delayed_task` | `DelayedTask` |
+| `AsyncDelayedRouteBuilder` | `as_async_delayed_task` | `AsyncDelayedTask` |
+| `ScheduledRouteBuilder` | `as_scheduled_task` | `ScheduledTask` |
+| `AsyncScheduledRouteBuilder` | `as_async_scheduled_task` | `AsyncScheduledTask` |
+
+## Typed options
+
+Options accepted by `.options()`, `.scheduler()`, and `task_default_options` are `TypedDict`s
+(`DelayOptions`, `AsyncDelayOptions`, `SchedulerOptions`, `AsyncSchedulerOptions`, `TaskDefaultOptions`), so
+misspelled or wrongly-typed options are caught statically too:
+
+```python
+make_dinner.options(countdown="soon")  # type error: countdown expects int
+make_dinner.options(countdwn=60)       # type error: unknown option
+```
+
+## Caveats
+
+- Call `.delay()` and `.schedule()` with **keyword arguments** — the runtime only accepts keywords. The
+  protocols mirror the endpoint's full signature, so a positional call may typecheck but fail at runtime.
+- The decorators are casts: they tell the type checker the methods will exist. They do exist as soon as the
+  router is registered with `route_class=...` from the matching builder — using `as_delayed_task` on a plain
+  (non-delayed) route will typecheck but fail at runtime.
+
+See the [Typed protocols API reference](../api/protocols.md) for the full definitions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,19 @@
-# FastAPI GCP Tasks
+---
+description: >-
+  Strongly typed background tasks and cron jobs for FastAPI on Google Cloud —
+  a serverless celery alternative built on GCP Cloud Tasks, Cloud Scheduler,
+  and Cloud Run.
+---
 
-Strongly typed background tasks with FastAPI and Google Cloud Run, Tasks and Scheduler.
+# FastAPI GCP Tasks — background tasks on Google Cloud
+
+**Strongly typed background tasks and scheduled (cron) jobs for FastAPI**, built on **Google Cloud Tasks**,
+**Cloud Scheduler**, and **Cloud Run** — a serverless, autoscaling alternative to celery workers and celery
+beat, with no RabbitMQ or Redis broker to run.
 
 Your tasks are regular FastAPI endpoints. Trigger one later with `.delay()`, or on a cron schedule with
-`.scheduler()` — Cloud Tasks and Cloud Scheduler make the HTTP calls back to your service.
+`.scheduler()` — GCP's Cloud Tasks queue and Cloud Scheduler make the HTTP calls back to your service, with
+retries, deduplication, and rate control handled by the queue.
 
 ```mermaid
 sequenceDiagram
@@ -56,21 +66,22 @@ sequenceDiagram
     - With a FaaS setup, your task workers can autoscale based on load.
     - Most FaaS services have free tiers, making it much cheaper than running a celery worker.
 
-## The concept
+## A celery alternative on GCP
 
-[Cloud Tasks](https://cloud.google.com/tasks) allows us to schedule an HTTP request in the future.
+[Cloud Tasks](https://cloud.google.com/tasks) allows us to schedule an HTTP request in the future — a fully
+managed task queue on Google Cloud.
 
 [FastAPI](https://fastapi.tiangolo.com/tutorial/body/) makes us define a complete schema and params for an
 HTTP endpoint.
 
 [Cloud Scheduler](https://cloud.google.com/scheduler) allows us to schedule recurring HTTP requests in the
-future.
+future — managed cron jobs on Google Cloud.
 
 FastAPI GCP Tasks works by putting the three together:
 
-- Cloud Tasks + FastAPI = partial replacement for celery's async delayed tasks.
-- Cloud Scheduler + FastAPI = replacement for celery beat.
-- FastAPI GCP Tasks + Cloud Run = autoscaled delayed tasks.
+- **GCP Cloud Tasks + FastAPI** = replacement for celery's async delayed tasks and task queue.
+- **GCP Cloud Scheduler + FastAPI** = replacement for celery beat (periodic tasks / cron jobs).
+- **FastAPI GCP Tasks + Cloud Run** = serverless, autoscaled background workers that scale to zero.
 
 ## Where to go next
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,90 @@
+# FastAPI GCP Tasks
+
+Strongly typed background tasks with FastAPI and Google Cloud Run, Tasks and Scheduler.
+
+Your tasks are regular FastAPI endpoints. Trigger one later with `.delay()`, or on a cron schedule with
+`.scheduler()` — Cloud Tasks and Cloud Scheduler make the HTTP calls back to your service.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant Service
+    participant CloudTasks
+    participant Worker
+
+
+    User ->>+ Service: /trigger
+
+
+    rect rgb(100,130,180)
+    note right of Service: hello.delay()
+    Service -->>+ CloudTasks: Create task
+    CloudTasks -->>- Service: Accepted
+    end
+
+    Service ->>- User: Hello task triggered
+    note right of CloudTasks: Async
+    CloudTasks -->>+ Worker: /hello
+    Worker -->>- CloudTasks: 200
+```
+
+## Key features
+
+- **Strongly typed tasks.**
+    - Fail at invocation site to make it easier to develop and debug.
+    - Breaking schema changes between versions will fail at task runner with Pydantic.
+    - Fully type-checked public API (PEP 561 `py.typed`), with opt-in static typing for
+      `.delay`/`.scheduler` — see [Type safety](guide/type-safety.md).
+- **Familiar and simple public API.**
+    - `.delay` method that takes the same arguments as the task.
+    - `.scheduler` method to create recurring jobs.
+    - Async variants (`AsyncDelayedRouteBuilder` / `AsyncScheduledRouteBuilder`) so `await .delay()`
+      never blocks the event loop.
+- **Tasks are regular FastAPI endpoints on plain old HTTP.**
+    - `Depends` just works!
+    - All middlewares, telemetry, auth, and debugging solutions for FastAPI work as is.
+    - Host task runners independent of GCP. If Cloud Tasks can reach the URL, it can invoke the task.
+- **Save money.**
+    - Task invocation with GCP is [free for the first million, then $0.40/million](https://cloud.google.com/tasks/pricing) —
+      almost always cheaper than running a RabbitMQ/Redis/SQL backend for celery.
+    - Jobs cost [$0.10 per job per month irrespective of invocations; 3 jobs are free](https://cloud.google.com/scheduler#pricing) —
+      either free or almost always cheaper than an always-running beat worker.
+    - If this cost ever becomes a concern, the `client` can be overridden to call any gRPC server with a
+      compatible API, like [this emulator](https://github.com/aertje/cloud-tasks-emulator) used for local development.
+- **Autoscale.**
+    - With a FaaS setup, your task workers can autoscale based on load.
+    - Most FaaS services have free tiers, making it much cheaper than running a celery worker.
+
+## The concept
+
+[Cloud Tasks](https://cloud.google.com/tasks) allows us to schedule an HTTP request in the future.
+
+[FastAPI](https://fastapi.tiangolo.com/tutorial/body/) makes us define a complete schema and params for an
+HTTP endpoint.
+
+[Cloud Scheduler](https://cloud.google.com/scheduler) allows us to schedule recurring HTTP requests in the
+future.
+
+FastAPI GCP Tasks works by putting the three together:
+
+- Cloud Tasks + FastAPI = partial replacement for celery's async delayed tasks.
+- Cloud Scheduler + FastAPI = replacement for celery beat.
+- FastAPI GCP Tasks + Cloud Run = autoscaled delayed tasks.
+
+## Where to go next
+
+- [Getting started](getting-started.md) — install and run your first delayed task locally.
+- [Delayed tasks](guide/delayed-tasks.md) and [Scheduled tasks](guide/scheduled-tasks.md) — the two core
+  building blocks.
+- [Async usage](guide/async.md) — non-blocking task triggers from async endpoints.
+- [Type safety](guide/type-safety.md) — statically checked `.delay()` calls.
+- [API reference](api/route-builders.md) — full signatures, generated from the source.
+
+## License & disclaimer
+
+This project is licensed under the terms of the MIT license. It was forked from
+[fastapi-cloud-tasks](https://github.com/Adori/fastapi-cloud-tasks) under the MIT license; all changes made
+to the original project are also licensed under the MIT license.
+
+This project is neither affiliated with, nor sponsored by Google.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ beat, with no RabbitMQ or Redis broker to run.
 
 Your tasks are regular FastAPI endpoints. Trigger one later with `.delay()`, or on a cron schedule with
 `.scheduler()` — GCP's Cloud Tasks queue and Cloud Scheduler make the HTTP calls back to your service, with
-retries, deduplication, and rate control handled by the queue.
+retries and rate control handled by the queue (and opt-in deduplication by passing a stable `task_id`).
 
 ```mermaid
 sequenceDiagram

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,88 @@
+site_name: FastAPI GCP Tasks
+site_description: Strongly typed background tasks with FastAPI and Google Cloud Run, Tasks and Scheduler.
+site_url: https://simplifyjobs.github.io/fastapi-gcp-tasks/
+repo_url: https://github.com/SimplifyJobs/fastapi-gcp-tasks
+repo_name: SimplifyJobs/fastapi-gcp-tasks
+edit_uri: edit/master/docs/
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+    - search.suggest
+    - search.highlight
+
+nav:
+  - Home: index.md
+  - Getting started: getting-started.md
+  - Guide:
+      - Delayed tasks: guide/delayed-tasks.md
+      - Scheduled tasks: guide/scheduled-tasks.md
+      - Async usage: guide/async.md
+      - Type safety: guide/type-safety.md
+      - Hooks & dependencies: guide/hooks-and-dependencies.md
+      - Configuration: guide/configuration.md
+      - Deploying to Cloud Run: guide/deployment.md
+  - API reference:
+      - Route builders: api/route-builders.md
+      - Typed protocols: api/protocols.md
+      - Delayers & schedulers: api/delayers-and-schedulers.md
+      - Hooks: api/hooks.md
+      - Dependencies: api/dependencies.md
+      - Utilities: api/utils.md
+      - Exceptions: api/exceptions.md
+  - Contributing: contributing.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: numpy
+            show_root_heading: true
+            show_source: true
+            show_signature_annotations: true
+            separate_signature: true
+            members_order: source
+            merge_init_into_class: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: FastAPI GCP Tasks
-site_description: Strongly typed background tasks with FastAPI and Google Cloud Run, Tasks and Scheduler.
+site_description: >-
+  Strongly typed background tasks and cron jobs for FastAPI on Google Cloud (GCP) —
+  a serverless celery alternative built on Cloud Tasks, Cloud Scheduler, and Cloud Run.
 site_url: https://simplifyjobs.github.io/fastapi-gcp-tasks/
 repo_url: https://github.com/SimplifyJobs/fastapi-gcp-tasks
 repo_name: SimplifyJobs/fastapi-gcp-tasks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dev = [
     "pytest-asyncio>=1.4.0",
     "types-requests>=2.33.0.20260518",
 ]
+docs = [
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.26",
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/uv.lock
+++ b/uv.lock
@@ -63,6 +63,27 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -279,6 +300,10 @@ dev = [
     { name = "types-ujson" },
     { name = "uvicorn" },
 ]
+docs = [
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+]
 
 [package.metadata]
 requires-dist = [
@@ -299,6 +324,22 @@ dev = [
     { name = "types-requests", specifier = ">=2.33.0.20260518" },
     { name = "types-ujson", specifier = ">=5.10.0.20240515" },
     { name = "uvicorn", specifier = ">=0.41.0" },
+]
+docs = [
+    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
 ]
 
 [[package]]
@@ -384,6 +425,15 @@ wheels = [
 [package.optional-dependencies]
 grpc = [
     { name = "grpcio" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -483,6 +533,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -528,6 +590,195 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/0b/a55244261d9ad7375ac039b8af06d42602722e2e8b8d8d6b86e4a3888c02/librt-0.12.0-cp313-cp313-win32.whl", hash = "sha256:da58944be8270f2bfee628a9a2a60c1cf6a12c8bea8e2c9b6edf3e5414ca7793", size = 99308, upload-time = "2026-06-30T16:13:23.661Z" },
     { url = "https://files.pythonhosted.org/packages/c9/bf/ed9465e58d44c5a5637795547d0841c8934aab905ea452cac1adf14672cf/librt-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:1db4be3037e4ce065a071fa7deee93e78ebc25f448340a02a6c1c0b82c37e383", size = 119438, upload-time = "2026-06-30T16:13:25.188Z" },
     { url = "https://files.pythonhosted.org/packages/c0/44/3cad652aeb892e6e8ffe48d0fafa2bc652f28ec7ed3f4403fcbb1be4f948/librt-0.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:05fd2542892ad770b5dd45003fd080477cf220b611d3ee59b0792097eb0873a9", size = 105118, upload-time = "2026-06-30T16:13:26.533Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/5d/f888d4d3eb31359b327bc9b17a212d6ef03fe0b0682fbb3fc2cb849fb12b/mkdocstrings-1.0.4.tar.gz", hash = "sha256:3969a6515b77db65fd097b53c1b7aa4ae840bd71a2ee62a6a3e89503446d7172", size = 100088, upload-time = "2026-04-15T09:16:53.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/94/be70f8ee9c45f2f62b39a1f0e9303bc20e138a8f3b8e50ffd89498e177e1/mkdocstrings-1.0.4-py3-none-any.whl", hash = "sha256:63464b4b29053514f32a1dbbf604e52876d5e638111b0c295ab7ed3cac73ca9b", size = 35560, upload-time = "2026-04-15T09:16:51.436Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/b6/e858701499d57eee8b3fd8e78168083956c6683ddbe727b46758b19e1119/mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594", size = 199578, upload-time = "2026-06-19T10:41:08.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/fc/10ab7e80650a9c9e8f4f1105f8c8e73567f88ed0c06ada589ab81d38687c/mkdocstrings_python-2.0.5-py3-none-any.whl", hash = "sha256:30c837bbff016549f659fcba6539ac351303f0fd7e713c89a040611072236e9d", size = 104951, upload-time = "2026-06-19T10:41:07.378Z" },
 ]
 
 [[package]]
@@ -586,12 +837,30 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -771,6 +1040,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -800,12 +1082,73 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -846,6 +1189,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
     { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
     { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -932,4 +1284,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]


### PR DESCRIPTION
## Summary

Stacked on #117 (the guides and API reference document the typed API introduced there).

Adds a full documentation site to help promote the library and communicate its types:

- **MkDocs Material** site at `docs/` — home page with the sequence diagram and feature pitch, getting-started quickstart, and guides for delayed tasks, scheduled tasks, async usage, **type safety**, hooks & dependencies, configuration (option tables for all four route builders), and Cloud Run deployment.
- **API reference generated from source** via mkdocstrings — route builders, typed protocols/TypedDicts, delayers & schedulers, hooks, dependencies, utils, and exceptions. Signatures render with full type annotations, so the typing work in #117 is surfaced directly in the docs.
- **CI/CD**: `.github/workflows/docs.yml` strict-builds the docs on every PR (read-only token) and, on pushes to `master`, publishes the exact validated artifact via the official Pages actions (`upload-pages-artifact` + `deploy-pages`) — no `contents: write`, no gh-pages branch. Site URL: https://simplifyjobs.github.io/fastapi-gcp-tasks/
- **Developer UX**: `make docs` (live-reload server) and `make docs-build` (strict build), with docs deps in a separate `docs` dependency group.

> **Note for merging:** before/after the first deploy, set GitHub Pages source to **GitHub Actions** (Settings → Pages → Source → GitHub Actions) so the site URL resolves.

## Test plan

- [x] `uv run --group docs mkdocs build --strict` passes (no broken links/refs)
- [x] Verified mkdocstrings renders the API pages (route builders, protocols) from docstrings
- [x] `make lint` / `make test` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, dev tooling, and CI only; no changes to the library runtime or application logic.
> 
> **Overview**
> Introduces a **MkDocs Material** documentation site under `docs/`, with guides (getting started, delayed/scheduled tasks, async, type safety, hooks, configuration, Cloud Run) and an **API reference** pulled from source via **mkdocstrings**.
> 
> Adds **`mkdocs.yml`**, a **`docs` uv dependency group** (`mkdocs-material`, `mkdocstrings[python]`), and **`make docs` / `make docs-build`** for local serve and strict builds. The **README** now links to the published site.
> 
> **CI** (`.github/workflows/docs.yml`) runs `mkdocs build --strict` on PRs and master pushes; on **`master` only**, it uploads the built `site/` artifact and deploys with the official Pages actions (no `contents: write`, per-ref concurrency). Repo **Pages source** must be set to GitHub Actions for the URL to work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8575df51c626dc952e0604326b2157dd1445b5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `mkdocs-material` docs site with guides and a source-generated API reference, plus CI that strictly builds on PRs and deploys to GitHub Pages via the Pages artifact flow with serialized, safe deploys.

- **New Features**
  - Full docs site under `docs/`: getting started, guides (delayed, scheduled, async, type safety, hooks & dependencies, configuration, Cloud Run), contributing, and an SEO-focused home page with Office-themed examples.
  - API reference via `mkdocstrings` (typed signatures and protocols).
  - CI: strict `mkdocs build --strict` on PRs; deploy to Pages on `master` using `actions/upload-pages-artifact` + `actions/deploy-pages` at https://simplifyjobs.github.io/fastapi-gcp-tasks/.
  - Dev UX: `make docs`, `make docs-build`; `docs` dependency group with `mkdocs-material` and `mkdocstrings[python]`; README links to the site.

- **Bug Fixes**
  - Safer deploys: publish the exact strict-built artifact with no `contents: write`, split build/deploy jobs, and add per-ref concurrency; use `uv sync --locked` so stale locks fail CI.
  - Getting started: use `logger.warning`, trigger from a sync endpoint to avoid blocking, and run the file the reader created.
  - Clarify that Cloud Tasks deduplication is opt-in via a stable `task_id`.

<sup>Written for commit f8575df51c626dc952e0604326b2157dd1445b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SimplifyJobs/fastapi-gcp-tasks/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

