### PR TITLE
fix: support callback URLs for nested FastAPI routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ if IS_LOCAL:
 # This can be done once across the entire project
 DelayedRoute = DelayedRouteBuilder(
     client=client,
-    base_url="http://localhost:8000"
+    callback_base_url="http://localhost:8000",
     queue_path=queue_path(
         project="gcp-project-id",
         location="us-central1",
@@ -333,17 +333,17 @@ Pre-requisites:
 
 ```python
 # URL of the Cloud Run service
-base_url = "https://hello-randomchars-el.a.run.app"
+service_url = "https://hello-randomchars-el.a.run.app"
 
 DelayedRoute = DelayedRouteBuilder(
-    base_url=base_url,
+    callback_base_url=service_url,
     # Task queue, same as above.
     queue_path=queue_path(...),
     pre_create_hook=oidc_task_hook(
         token=tasks_v2.OidcToken(
             # Service account that you created
             service_account_email="fastapi-gcp-tasks@gcp-project-id.iam.gserviceaccount.com",
-            audience=base_url,
+            audience=service_url,
         ),
     ),
 )
@@ -370,7 +370,10 @@ def simple_task():
     return {}
 ```
 
-- `base_url` - The URL of your worker FastAPI service.
+- `callback_base_url` - The externally reachable URL prefix to which the task route's own path is appended.
+  Include any prefix added later by an outer `include_router()` call.
+
+- `base_url` - Legacy alias for `callback_base_url`. Pass only one of the two.
 
 - `queue_path` - Full path of the Cloud Tasks queue. (Hint: use the util function `queue_path`)
 
@@ -416,7 +419,8 @@ Usage:
 simple_task.options(...).delay()
 ```
 
-All options from above can be overwritten per call (including DelayedRouteBuilder options like `base_url`) with kwargs to the `options` function before calling delay.
+All options from above can be overwritten per call (including `callback_base_url`) with kwargs to the `options`
+function before calling delay.
 
 Example:
 
@@ -424,6 +428,38 @@ Example:
 # Trigger after 2 minutes
 simple_task.options(countdown=120).delay()
 ```
+
+#### Routers mounted under an outer prefix
+
+FastAPI 0.137 and later preserve included routers instead of cloning their routes. A route class therefore knows the
+path declared on its own router, but it cannot unambiguously infer a prefix added later—especially because the same
+router can be included more than once. Put that externally visible prefix in `callback_base_url`:
+
+```python
+service_url = "https://worker.example.com"
+
+DelayedRoute = DelayedRouteBuilder(
+    callback_base_url=f"{service_url}/tasks",
+    queue_path=queue_path(...),
+    pre_create_hook=oidc_delayed_hook(
+        token=tasks_v2.OidcToken(
+            service_account_email="tasks@example.iam.gserviceaccount.com",
+            audience=service_url,
+        ),
+    ),
+)
+
+task_router = APIRouter(route_class=DelayedRoute, prefix="/auth")
+
+@task_router.post("/confirm/{user_id}")
+def confirm_user(user_id: str): ...
+
+app.include_router(task_router, prefix="/tasks")
+```
+
+`confirm_user.delay(user_id="42")` now targets
+`https://worker.example.com/tasks/auth/confirm/42`. The OIDC audience remains the service URL; it does not need the
+callback path prefix.
 
 ### AsyncDelayedRouteBuilder
 

--- a/README.md
+++ b/README.md
@@ -470,6 +470,8 @@ Same options as `DelayedRouteBuilder`, with two differences:
 - `auto_create_queue` - Defaults to `False` (the sync builder defaults to `True`). When `True`, the queue is
   ensured lazily on the first `.delay()`. Prefer calling `ensure_queue_async` from your lifespan instead.
 
+The same `callback_base_url` rule applies when an async delayed router is mounted under an outer prefix.
+
 ### ScheduledRouteBuilder
 
 Usage:
@@ -486,11 +488,34 @@ def simple_scheduled_task():
 simple_scheduled_task.scheduler(name="simple_scheduled_task", schedule="* * * * *").schedule()
 ```
 
+`callback_base_url` has the same meaning as it does for delayed routes: it is the externally reachable URL prefix to
+which the scheduled route's own path is appended. Include prefixes added by an outer `include_router()` call:
+
+```python
+service_url = "https://worker.example.com"
+
+ScheduledRoute = ScheduledRouteBuilder(
+    callback_base_url=f"{service_url}/tasks",
+    location_path="projects/my-project/locations/us-central1",
+)
+scheduled_router = APIRouter(route_class=ScheduledRoute, prefix="/maintenance")
+
+@scheduled_router.post("/sweep")
+def sweep(): ...
+
+app.include_router(scheduled_router, prefix="/tasks")
+```
+
+The scheduled callback is `https://worker.example.com/tasks/maintenance/sweep`. As with delayed tasks, keep a Cloud
+Run OIDC audience set to `service_url`, without the callback path prefix. `base_url` remains a legacy alias for
+`callback_base_url`; pass only one.
+
 ### AsyncScheduledRouteBuilder
 
 Same options as `ScheduledRouteBuilder`, except `client` accepts a `CloudSchedulerAsyncClient`, a
 zero-argument factory returning one, or `None` (resolved lazily, as above). `.schedule()` and `.delete()`
-are coroutines — await them from a lifespan or a request handler.
+are coroutines — await them from a lifespan or a request handler. The same nested-router `callback_base_url` rule
+applies to async scheduled routes.
 
 
 ## Hooks

--- a/examples/full/tasks.py
+++ b/examples/full/tasks.py
@@ -47,7 +47,7 @@ if IS_LOCAL:
 
 DelayedRoute = DelayedRouteBuilder(
     client=delayed_client,
-    base_url=TASK_LISTENER_BASE_URL,
+    callback_base_url=TASK_LISTENER_BASE_URL,
     queue_path=TASK_QUEUE_PATH,
     # Chain multiple hooks together
     pre_create_hook=chained_hook(
@@ -72,7 +72,7 @@ if IS_LOCAL:
 
 ScheduledRoute = ScheduledRouteBuilder(
     client=scheduled_client,
-    base_url=TASK_LISTENER_BASE_URL,
+    callback_base_url=TASK_LISTENER_BASE_URL,
     location_path=SCHEDULED_LOCATION_PATH,
     pre_create_hook=chained_hook(
         # Add service account for cloud run
@@ -93,7 +93,7 @@ def _local_async_delayed_client() -> tasks_v2.CloudTasksAsyncClient:
 
 AsyncDelayedRoute = AsyncDelayedRouteBuilder(
     client=_local_async_delayed_client if IS_LOCAL else None,
-    base_url=TASK_LISTENER_BASE_URL,
+    callback_base_url=TASK_LISTENER_BASE_URL,
     queue_path=TASK_QUEUE_PATH,
     auto_create_queue=True,
     pre_create_hook=chained_hook(

--- a/examples/simple/main.py
+++ b/examples/simple/main.py
@@ -21,8 +21,8 @@ if IS_LOCAL:
 
 DelayedRoute = DelayedRouteBuilder(
     client=client,
-    # Base URL where the task server will get hosted
-    base_url=os.getenv("TASK_LISTENER_BASE_URL", default="http://localhost:8000"),
+    # Externally reachable URL prefix where the task routes are hosted
+    callback_base_url=os.getenv("TASK_LISTENER_BASE_URL", default="http://localhost:8000"),
     # Full queue path to which we'll send tasks.
     # Edit values below to match your project
     queue_path=queue_path(

--- a/fastapi_gcp_tasks/_callback_url.py
+++ b/fastapi_gcp_tasks/_callback_url.py
@@ -1,0 +1,19 @@
+"""Callback URL option resolution shared by route builders."""
+
+
+def resolve_callback_base_url(
+    *,
+    callback_base_url: str | None,
+    base_url: str | None,
+    default: str | None = None,
+) -> str:
+    """Resolve the preferred callback URL option and its legacy alias."""
+    if callback_base_url is not None and base_url is not None:
+        raise TypeError("Pass callback_base_url or base_url, not both")
+    if callback_base_url is not None:
+        return callback_base_url
+    if base_url is not None:
+        return base_url
+    if default is not None:
+        return default
+    raise TypeError("Missing required keyword argument: callback_base_url (or legacy base_url)")

--- a/fastapi_gcp_tasks/_endpoint_binding.py
+++ b/fastapi_gcp_tasks/_endpoint_binding.py
@@ -1,0 +1,46 @@
+"""Bind task helpers to endpoints without hiding ambiguous route registrations."""
+
+# Standard Library Imports
+from collections.abc import Callable, Mapping
+from typing import Any
+
+# Third Party Imports
+from fastapi import __version__ as fastapi_version
+from fastapi.routing import APIRoute
+
+_FASTAPI_PRESERVES_ROUTER_TREES = tuple(int(part) for part in fastapi_version.split(".")[:2]) >= (0, 137)
+
+
+def bind_endpoint_methods(
+    route: APIRoute,
+    *,
+    primary_method_name: str,
+    methods: Mapping[str, Callable[..., Any]],
+) -> None:
+    """Attach task methods once, allowing only old FastAPI inclusion clones to reuse them."""
+    existing_method = getattr(route.endpoint, primary_method_name, None)
+    if existing_method is None:
+        for name, method in methods.items():
+            setattr(route.endpoint, name, method)
+        return
+
+    existing_route = getattr(existing_method, "__self__", None)
+    if _is_inclusion_clone(existing_route=existing_route, route=route):
+        return
+
+    endpoint_name = getattr(route.endpoint, "__name__", repr(route.endpoint))
+    existing_path = getattr(existing_route, "path", "an unknown path")
+    raise ValueError(
+        f"Endpoint {endpoint_name!r} is already registered as a task at {existing_path!r}; "
+        f"it cannot also be registered at {route.path!r} because its function-level "
+        f".{primary_method_name} helper can represent only one callback path."
+    )
+
+
+def _is_inclusion_clone(*, existing_route: object, route: APIRoute) -> bool:
+    """Return whether ``route`` is a copy made by FastAPI's old ``include_router`` implementation."""
+    if not isinstance(existing_route, APIRoute) or type(existing_route) is not type(route):
+        return False
+    if route.path == existing_route.path:
+        return True
+    return not _FASTAPI_PRESERVES_ROUTER_TREES and route.path.endswith(existing_route.path)

--- a/fastapi_gcp_tasks/_endpoint_binding.py
+++ b/fastapi_gcp_tasks/_endpoint_binding.py
@@ -5,10 +5,22 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 # Third Party Imports
-from fastapi import __version__ as fastapi_version
 from fastapi.routing import APIRoute
 
-_FASTAPI_PRESERVES_ROUTER_TREES = tuple(int(part) for part in fastapi_version.split(".")[:2]) >= (0, 137)
+
+class _RouteInclusionMarker(dict[str, Any]):
+    """
+    Carry route identity through FastAPI's old inclusion clone path.
+
+    FastAPI through 0.136 forwards the exact ``openapi_extra`` object when
+    cloning a route. A dict subclass preserves every user-supplied OpenAPI
+    value while keeping ``origin`` as Python-only metadata that is never
+    emitted into the schema.
+    """
+
+    def __init__(self, *, origin: APIRoute, openapi_extra: dict[str, Any] | None) -> None:
+        super().__init__(openapi_extra or {})
+        self.origin = origin
 
 
 def bind_endpoint_methods(
@@ -22,6 +34,10 @@ def bind_endpoint_methods(
     if existing_method is None:
         for name, method in methods.items():
             setattr(route.endpoint, name, method)
+        route.openapi_extra = _RouteInclusionMarker(
+            origin=route,
+            openapi_extra=route.openapi_extra,
+        )
         return
 
     existing_route = getattr(existing_method, "__self__", None)
@@ -39,8 +55,10 @@ def bind_endpoint_methods(
 
 def _is_inclusion_clone(*, existing_route: object, route: APIRoute) -> bool:
     """Return whether ``route`` is a copy made by FastAPI's old ``include_router`` implementation."""
-    if not isinstance(existing_route, APIRoute) or type(existing_route) is not type(route):
-        return False
-    if route.path == existing_route.path:
-        return True
-    return not _FASTAPI_PRESERVES_ROUTER_TREES and route.path.endswith(existing_route.path)
+    marker = route.openapi_extra
+    return (
+        isinstance(existing_route, APIRoute)
+        and type(existing_route) is type(route)
+        and isinstance(marker, _RouteInclusionMarker)
+        and marker.origin is existing_route
+    )

--- a/fastapi_gcp_tasks/async_delayed_route.py
+++ b/fastapi_gcp_tasks/async_delayed_route.py
@@ -7,6 +7,7 @@ from google.cloud import tasks_v2
 
 # Imports from this repository
 from fastapi_gcp_tasks._callback_url import resolve_callback_base_url
+from fastapi_gcp_tasks._endpoint_binding import bind_endpoint_methods
 from fastapi_gcp_tasks.async_delayer import (
     AsyncCloudTasksClientFactory,
     AsyncCloudTasksClientProvider,
@@ -79,13 +80,11 @@ def AsyncDelayedRouteBuilder(  # noqa: N802
     class AsyncTaskRouteMixin(APIRoute):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             super().__init__(*args, **kwargs)
-            existing_delay = getattr(self.endpoint, "delay", None)
-            # FastAPI <0.137 clones routes during inclusion. Keep the endpoint
-            # bound to its original route so callback prefixing stays explicit.
-            if isinstance(getattr(existing_delay, "__self__", None), AsyncTaskRouteMixin):
-                return
-            self.endpoint.options = self.delay_options  # type: ignore[attr-defined]
-            self.endpoint.delay = self.delay  # type: ignore[attr-defined]
+            bind_endpoint_methods(
+                self,
+                primary_method_name="delay",
+                methods={"options": self.delay_options, "delay": self.delay},
+            )
 
         def delay_options(self, **options: Unpack[AsyncDelayOptions]) -> AsyncDelayer:
             ensure_known_options(options, AsyncDelayOptions)

--- a/fastapi_gcp_tasks/async_delayed_route.py
+++ b/fastapi_gcp_tasks/async_delayed_route.py
@@ -1,13 +1,12 @@
 # Standard Library Imports
-from collections.abc import Callable, Coroutine
 from typing import Any, Unpack
 
 # Third Party Imports
-from fastapi import Request, Response
 from fastapi.routing import APIRoute
 from google.cloud import tasks_v2
 
 # Imports from this repository
+from fastapi_gcp_tasks._callback_url import resolve_callback_base_url
 from fastapi_gcp_tasks.async_delayer import (
     AsyncCloudTasksClientFactory,
     AsyncCloudTasksClientProvider,
@@ -19,8 +18,9 @@ from fastapi_gcp_tasks.protocols import AsyncDelayOptions, ensure_known_options
 
 def AsyncDelayedRouteBuilder(  # noqa: N802
     *,
-    base_url: str,
     queue_path: str,
+    callback_base_url: str | None = None,
+    base_url: str | None = None,
     task_create_timeout: float = 10.0,
     pre_create_hook: DelayedTaskHook | None = None,
     client: tasks_v2.CloudTasksAsyncClient | AsyncCloudTasksClientFactory | None = None,
@@ -30,6 +30,10 @@ def AsyncDelayedRouteBuilder(  # noqa: N802
     Returns a Mixin that should be used to override route_class, with an awaitable .delay.
 
     It adds awaitable .delay and sync .options methods to the original endpoint.
+
+    ``callback_base_url`` is the externally reachable URL prefix to which the
+    route's own path is appended. It should include prefixes added by an outer
+    ``include_router`` call. ``base_url`` is retained as a legacy alias.
 
     ``client`` may be a CloudTasksAsyncClient, a zero-argument factory returning one,
     or None (default client). grpc.aio channels bind to the event loop active at
@@ -64,16 +68,24 @@ def AsyncDelayedRouteBuilder(  # noqa: N802
     ```
 
     """
+    resolved_callback_base_url = resolve_callback_base_url(
+        callback_base_url=callback_base_url,
+        base_url=base_url,
+    )
     hook: DelayedTaskHook = pre_create_hook if pre_create_hook is not None else noop_hook
 
     client_provider = AsyncCloudTasksClientProvider(client=client, auto_create_queue=auto_create_queue)
 
     class AsyncTaskRouteMixin(APIRoute):
-        def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
-            original_route_handler = super().get_route_handler()
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            existing_delay = getattr(self.endpoint, "delay", None)
+            # FastAPI <0.137 clones routes during inclusion. Keep the endpoint
+            # bound to its original route so callback prefixing stays explicit.
+            if isinstance(getattr(existing_delay, "__self__", None), AsyncTaskRouteMixin):
+                return
             self.endpoint.options = self.delay_options  # type: ignore[attr-defined]
             self.endpoint.delay = self.delay  # type: ignore[attr-defined]
-            return original_route_handler
 
         def delay_options(self, **options: Unpack[AsyncDelayOptions]) -> AsyncDelayer:
             ensure_known_options(options, AsyncDelayOptions)
@@ -93,7 +105,11 @@ def AsyncDelayedRouteBuilder(  # noqa: N802
 
             return AsyncDelayer(
                 route=self,
-                base_url=opts.get("base_url", base_url),
+                base_url=resolve_callback_base_url(
+                    callback_base_url=opts.get("callback_base_url"),
+                    base_url=opts.get("base_url"),
+                    default=resolved_callback_base_url,
+                ),
                 queue_path=opts.get("queue_path", queue_path),
                 task_create_timeout=opts.get("task_create_timeout", task_create_timeout),
                 client_provider=provider,

--- a/fastapi_gcp_tasks/async_scheduled_route.py
+++ b/fastapi_gcp_tasks/async_scheduled_route.py
@@ -1,13 +1,12 @@
 # Standard Library Imports
-from collections.abc import Callable, Coroutine
 from typing import Any, Unpack
 
 # Third Party Imports
-from fastapi import Request, Response
 from fastapi.routing import APIRoute
 from google.cloud import scheduler_v1
 
 # Imports from this repository
+from fastapi_gcp_tasks._callback_url import resolve_callback_base_url
 from fastapi_gcp_tasks.async_clients import AsyncClientProvider
 from fastapi_gcp_tasks.async_scheduler import AsyncCloudSchedulerClientFactory, AsyncScheduler
 from fastapi_gcp_tasks.hooks import ScheduledHook, noop_hook
@@ -16,8 +15,9 @@ from fastapi_gcp_tasks.protocols import AsyncSchedulerOptions, ensure_known_opti
 
 def AsyncScheduledRouteBuilder(  # noqa: N802
     *,
-    base_url: str,
     location_path: str,
+    callback_base_url: str | None = None,
+    base_url: str | None = None,
     job_create_timeout: float = 10.0,
     pre_create_hook: ScheduledHook | None = None,
     client: scheduler_v1.CloudSchedulerAsyncClient | AsyncCloudSchedulerClientFactory | None = None,
@@ -28,6 +28,10 @@ def AsyncScheduledRouteBuilder(  # noqa: N802
     It adds a .scheduler method to the original endpoint whose .schedule and .delete
     coroutines must be awaited. Unlike ScheduledRouteBuilder, .schedule() cannot run at
     module import time — await it from a FastAPI lifespan or a request handler.
+
+    ``callback_base_url`` is the externally reachable URL prefix to which the
+    route's own path is appended. It should include prefixes added by an outer
+    ``include_router`` call. ``base_url`` is retained as a legacy alias.
 
     ``client`` may be a CloudSchedulerAsyncClient, a zero-argument factory returning
     one, or None (default client). grpc.aio channels bind to the event loop active at
@@ -53,16 +57,24 @@ def AsyncScheduledRouteBuilder(  # noqa: N802
     ```
 
     """
+    resolved_callback_base_url = resolve_callback_base_url(
+        callback_base_url=callback_base_url,
+        base_url=base_url,
+    )
     hook: ScheduledHook = pre_create_hook if pre_create_hook is not None else noop_hook
 
     # One provider per builder so every scheduler reuses the same client and channel
     client_provider = AsyncClientProvider(client=client, client_cls=scheduler_v1.CloudSchedulerAsyncClient)
 
     class AsyncScheduledRouteMixin(APIRoute):
-        def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
-            original_route_handler = super().get_route_handler()
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            existing_scheduler = getattr(self.endpoint, "scheduler", None)
+            # FastAPI <0.137 clones routes during inclusion. Keep the endpoint
+            # bound to its original route so callback prefixing stays explicit.
+            if isinstance(getattr(existing_scheduler, "__self__", None), AsyncScheduledRouteMixin):
+                return
             self.endpoint.scheduler = self.scheduler_options  # type: ignore[attr-defined]
-            return original_route_handler
 
         def scheduler_options(
             self, *, name: str, schedule: str, **options: Unpack[AsyncSchedulerOptions]
@@ -78,7 +90,11 @@ def AsyncScheduledRouteBuilder(  # noqa: N802
 
             return AsyncScheduler(
                 route=self,
-                base_url=options.get("base_url", base_url),
+                base_url=resolve_callback_base_url(
+                    callback_base_url=options.get("callback_base_url"),
+                    base_url=options.get("base_url"),
+                    default=resolved_callback_base_url,
+                ),
                 location_path=options.get("location_path", location_path),
                 schedule=schedule,
                 client_provider=provider,

--- a/fastapi_gcp_tasks/async_scheduled_route.py
+++ b/fastapi_gcp_tasks/async_scheduled_route.py
@@ -7,6 +7,7 @@ from google.cloud import scheduler_v1
 
 # Imports from this repository
 from fastapi_gcp_tasks._callback_url import resolve_callback_base_url
+from fastapi_gcp_tasks._endpoint_binding import bind_endpoint_methods
 from fastapi_gcp_tasks.async_clients import AsyncClientProvider
 from fastapi_gcp_tasks.async_scheduler import AsyncCloudSchedulerClientFactory, AsyncScheduler
 from fastapi_gcp_tasks.hooks import ScheduledHook, noop_hook
@@ -69,12 +70,11 @@ def AsyncScheduledRouteBuilder(  # noqa: N802
     class AsyncScheduledRouteMixin(APIRoute):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             super().__init__(*args, **kwargs)
-            existing_scheduler = getattr(self.endpoint, "scheduler", None)
-            # FastAPI <0.137 clones routes during inclusion. Keep the endpoint
-            # bound to its original route so callback prefixing stays explicit.
-            if isinstance(getattr(existing_scheduler, "__self__", None), AsyncScheduledRouteMixin):
-                return
-            self.endpoint.scheduler = self.scheduler_options  # type: ignore[attr-defined]
+            bind_endpoint_methods(
+                self,
+                primary_method_name="scheduler",
+                methods={"scheduler": self.scheduler_options},
+            )
 
         def scheduler_options(
             self, *, name: str, schedule: str, **options: Unpack[AsyncSchedulerOptions]

--- a/fastapi_gcp_tasks/delayed_route.py
+++ b/fastapi_gcp_tasks/delayed_route.py
@@ -7,6 +7,7 @@ from google.cloud import tasks_v2
 
 # Imports from this repository
 from fastapi_gcp_tasks._callback_url import resolve_callback_base_url
+from fastapi_gcp_tasks._endpoint_binding import bind_endpoint_methods
 from fastapi_gcp_tasks.delayer import Delayer
 from fastapi_gcp_tasks.hooks import DelayedTaskHook, noop_hook
 from fastapi_gcp_tasks.protocols import DelayOptions, ensure_known_options
@@ -66,13 +67,11 @@ def DelayedRouteBuilder(  # noqa: N802
     class TaskRouteMixin(APIRoute):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             super().__init__(*args, **kwargs)
-            existing_delay = getattr(self.endpoint, "delay", None)
-            # FastAPI <0.137 clones routes during inclusion. Keep the endpoint
-            # bound to its original route so callback prefixing stays explicit.
-            if isinstance(getattr(existing_delay, "__self__", None), TaskRouteMixin):
-                return
-            self.endpoint.options = self.delay_options  # type: ignore[attr-defined]
-            self.endpoint.delay = self.delay  # type: ignore[attr-defined]
+            bind_endpoint_methods(
+                self,
+                primary_method_name="delay",
+                methods={"options": self.delay_options, "delay": self.delay},
+            )
 
         def delay_options(self, **options: Unpack[DelayOptions]) -> Delayer:
             ensure_known_options(options, DelayOptions)

--- a/fastapi_gcp_tasks/delayed_route.py
+++ b/fastapi_gcp_tasks/delayed_route.py
@@ -1,13 +1,12 @@
 # Standard Library Imports
-from collections.abc import Callable, Coroutine
 from typing import Any, Unpack
 
 # Third Party Imports
-from fastapi import Request, Response
 from fastapi.routing import APIRoute
 from google.cloud import tasks_v2
 
 # Imports from this repository
+from fastapi_gcp_tasks._callback_url import resolve_callback_base_url
 from fastapi_gcp_tasks.delayer import Delayer
 from fastapi_gcp_tasks.hooks import DelayedTaskHook, noop_hook
 from fastapi_gcp_tasks.protocols import DelayOptions, ensure_known_options
@@ -16,8 +15,9 @@ from fastapi_gcp_tasks.utils import ensure_queue
 
 def DelayedRouteBuilder(  # noqa: N802
     *,
-    base_url: str,
     queue_path: str,
+    callback_base_url: str | None = None,
+    base_url: str | None = None,
     task_create_timeout: float = 10.0,
     pre_create_hook: DelayedTaskHook | None = None,
     client: tasks_v2.CloudTasksClient | None = None,
@@ -27,6 +27,10 @@ def DelayedRouteBuilder(  # noqa: N802
     Returns a Mixin that should be used to override route_class.
 
     It adds a .delay and .options methods to the original endpoint.
+
+    ``callback_base_url`` is the externally reachable URL prefix to which the
+    route's own path is appended. It should include prefixes added by an outer
+    ``include_router`` call. ``base_url`` is retained as a legacy alias.
 
     Example:
     -------
@@ -49,6 +53,10 @@ def DelayedRouteBuilder(  # noqa: N802
     ```
 
     """
+    resolved_callback_base_url = resolve_callback_base_url(
+        callback_base_url=callback_base_url,
+        base_url=base_url,
+    )
     task_client = client if client is not None else tasks_v2.CloudTasksClient()
     hook: DelayedTaskHook = pre_create_hook if pre_create_hook is not None else noop_hook
 
@@ -56,11 +64,15 @@ def DelayedRouteBuilder(  # noqa: N802
         ensure_queue(client=task_client, path=queue_path)
 
     class TaskRouteMixin(APIRoute):
-        def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
-            original_route_handler = super().get_route_handler()
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            existing_delay = getattr(self.endpoint, "delay", None)
+            # FastAPI <0.137 clones routes during inclusion. Keep the endpoint
+            # bound to its original route so callback prefixing stays explicit.
+            if isinstance(getattr(existing_delay, "__self__", None), TaskRouteMixin):
+                return
             self.endpoint.options = self.delay_options  # type: ignore[attr-defined]
             self.endpoint.delay = self.delay  # type: ignore[attr-defined]
-            return original_route_handler
 
         def delay_options(self, **options: Unpack[DelayOptions]) -> Delayer:
             ensure_known_options(options, DelayOptions)
@@ -81,7 +93,11 @@ def DelayedRouteBuilder(  # noqa: N802
 
             return Delayer(
                 route=self,
-                base_url=opts.get("base_url", base_url),
+                base_url=resolve_callback_base_url(
+                    callback_base_url=opts.get("callback_base_url"),
+                    base_url=opts.get("base_url"),
+                    default=resolved_callback_base_url,
+                ),
                 queue_path=opts.get("queue_path", queue_path),
                 task_create_timeout=opts.get("task_create_timeout", task_create_timeout),
                 client=resolved_client,

--- a/fastapi_gcp_tasks/protocols.py
+++ b/fastapi_gcp_tasks/protocols.py
@@ -23,6 +23,7 @@ class TaskDefaultOptions(TypedDict, total=False):
     countdown: int
     task_id: str
     task_create_timeout: float
+    callback_base_url: str
     base_url: str
     queue_path: str
     pre_create_hook: DelayedTaskHook
@@ -43,6 +44,7 @@ class AsyncDelayOptions(TaskDefaultOptions, total=False):
 class SchedulerOptions(TypedDict, total=False):
     """Per-call overrides accepted by ``.scheduler()`` on a scheduled task endpoint."""
 
+    callback_base_url: str
     base_url: str
     location_path: str
     job_create_timeout: float
@@ -56,6 +58,7 @@ class SchedulerOptions(TypedDict, total=False):
 class AsyncSchedulerOptions(TypedDict, total=False):
     """Per-call overrides accepted by ``.scheduler()`` on an async scheduled task endpoint."""
 
+    callback_base_url: str
     base_url: str
     location_path: str
     job_create_timeout: float

--- a/fastapi_gcp_tasks/scheduled_route.py
+++ b/fastapi_gcp_tasks/scheduled_route.py
@@ -7,6 +7,7 @@ from google.cloud import scheduler_v1
 
 # Imports from this repository
 from fastapi_gcp_tasks._callback_url import resolve_callback_base_url
+from fastapi_gcp_tasks._endpoint_binding import bind_endpoint_methods
 from fastapi_gcp_tasks.hooks import ScheduledHook, noop_hook
 from fastapi_gcp_tasks.protocols import SchedulerOptions, ensure_known_options
 from fastapi_gcp_tasks.scheduler import Scheduler
@@ -56,12 +57,11 @@ def ScheduledRouteBuilder(  # noqa: N802
     class ScheduledRouteMixin(APIRoute):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             super().__init__(*args, **kwargs)
-            existing_scheduler = getattr(self.endpoint, "scheduler", None)
-            # FastAPI <0.137 clones routes during inclusion. Keep the endpoint
-            # bound to its original route so callback prefixing stays explicit.
-            if isinstance(getattr(existing_scheduler, "__self__", None), ScheduledRouteMixin):
-                return
-            self.endpoint.scheduler = self.scheduler_options  # type: ignore[attr-defined]
+            bind_endpoint_methods(
+                self,
+                primary_method_name="scheduler",
+                methods={"scheduler": self.scheduler_options},
+            )
 
         def scheduler_options(self, *, name: str, schedule: str, **options: Unpack[SchedulerOptions]) -> Scheduler:
             ensure_known_options(options, SchedulerOptions)

--- a/fastapi_gcp_tasks/scheduled_route.py
+++ b/fastapi_gcp_tasks/scheduled_route.py
@@ -1,13 +1,12 @@
 # Standard Library Imports
-from collections.abc import Callable, Coroutine
 from typing import Any, Unpack
 
 # Third Party Imports
-from fastapi import Request, Response
 from fastapi.routing import APIRoute
 from google.cloud import scheduler_v1
 
 # Imports from this repository
+from fastapi_gcp_tasks._callback_url import resolve_callback_base_url
 from fastapi_gcp_tasks.hooks import ScheduledHook, noop_hook
 from fastapi_gcp_tasks.protocols import SchedulerOptions, ensure_known_options
 from fastapi_gcp_tasks.scheduler import Scheduler
@@ -15,8 +14,9 @@ from fastapi_gcp_tasks.scheduler import Scheduler
 
 def ScheduledRouteBuilder(  # noqa: N802
     *,
-    base_url: str,
     location_path: str,
+    callback_base_url: str | None = None,
+    base_url: str | None = None,
     job_create_timeout: float = 10.0,
     pre_create_hook: ScheduledHook | None = None,
     client: scheduler_v1.CloudSchedulerClient | None = None,
@@ -25,6 +25,10 @@ def ScheduledRouteBuilder(  # noqa: N802
     Returns a Mixin that should be used to override route_class.
 
     It adds a .scheduler method to the original endpoint.
+
+    ``callback_base_url`` is the externally reachable URL prefix to which the
+    route's own path is appended. It should include prefixes added by an outer
+    ``include_router`` call. ``base_url`` is retained as a legacy alias.
 
     Example:
     -------
@@ -42,14 +46,22 @@ def ScheduledRouteBuilder(  # noqa: N802
     ```
 
     """
+    resolved_callback_base_url = resolve_callback_base_url(
+        callback_base_url=callback_base_url,
+        base_url=base_url,
+    )
     scheduler_client = client if client is not None else scheduler_v1.CloudSchedulerClient()
     hook: ScheduledHook = pre_create_hook if pre_create_hook is not None else noop_hook
 
     class ScheduledRouteMixin(APIRoute):
-        def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
-            original_route_handler = super().get_route_handler()
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            existing_scheduler = getattr(self.endpoint, "scheduler", None)
+            # FastAPI <0.137 clones routes during inclusion. Keep the endpoint
+            # bound to its original route so callback prefixing stays explicit.
+            if isinstance(getattr(existing_scheduler, "__self__", None), ScheduledRouteMixin):
+                return
             self.endpoint.scheduler = self.scheduler_options  # type: ignore[attr-defined]
-            return original_route_handler
 
         def scheduler_options(self, *, name: str, schedule: str, **options: Unpack[SchedulerOptions]) -> Scheduler:
             ensure_known_options(options, SchedulerOptions)
@@ -65,7 +77,11 @@ def ScheduledRouteBuilder(  # noqa: N802
 
             return Scheduler(
                 route=self,
-                base_url=options.get("base_url", base_url),
+                base_url=resolve_callback_base_url(
+                    callback_base_url=options.get("callback_base_url"),
+                    base_url=options.get("base_url"),
+                    default=resolved_callback_base_url,
+                ),
                 location_path=options.get("location_path", location_path),
                 schedule=schedule,
                 client=resolved_client,

--- a/tests/test_callback_url.py
+++ b/tests/test_callback_url.py
@@ -1,0 +1,101 @@
+"""Tests for callback URL configuration and backward-compatible aliases."""
+
+# Standard Library Imports
+from typing import cast
+from unittest.mock import MagicMock
+
+# Third Party Imports
+import pytest
+from fastapi import APIRouter
+from google.cloud import tasks_v2
+
+# Imports from this repository
+from fastapi_gcp_tasks import DelayedRouteBuilder, as_delayed_task
+from fastapi_gcp_tasks._callback_url import resolve_callback_base_url
+from fastapi_gcp_tasks.delayer import Delayer
+
+QUEUE_PATH = "projects/test-project/locations/us-central1/queues/test-queue"
+
+
+@pytest.mark.parametrize(
+    ("callback_base_url", "base_url", "default", "expected"),
+    [
+        ("https://preferred.example", None, None, "https://preferred.example"),
+        (None, "https://legacy.example", None, "https://legacy.example"),
+        (None, None, "https://default.example", "https://default.example"),
+    ],
+)
+def test_resolve_callback_base_url(
+    callback_base_url: str | None,
+    base_url: str | None,
+    default: str | None,
+    expected: str,
+) -> None:
+    """The preferred option, legacy alias, and builder default should resolve in order."""
+    assert (
+        resolve_callback_base_url(
+            callback_base_url=callback_base_url,
+            base_url=base_url,
+            default=default,
+        )
+        == expected
+    )
+
+
+def test_resolve_callback_base_url_rejects_conflicting_names() -> None:
+    """Passing both the preferred option and legacy alias should fail clearly."""
+    with pytest.raises(TypeError, match="not both"):
+        resolve_callback_base_url(
+            callback_base_url="https://preferred.example",
+            base_url="https://legacy.example",
+        )
+
+
+def test_resolve_callback_base_url_requires_a_value() -> None:
+    """A builder without either callback URL spelling should fail clearly."""
+    with pytest.raises(TypeError, match="callback_base_url"):
+        resolve_callback_base_url(callback_base_url=None, base_url=None)
+
+
+def test_delayed_task_accepts_per_call_callback_base_override() -> None:
+    """A single delayed invocation should be able to target another callback base."""
+    client = MagicMock(spec=tasks_v2.CloudTasksClient)
+    route_class = DelayedRouteBuilder(
+        callback_base_url="https://default.example/tasks",
+        queue_path=QUEUE_PATH,
+        client=client,
+        auto_create_queue=False,
+    )
+    router = APIRouter(route_class=route_class)
+
+    @router.post("/task")
+    @as_delayed_task
+    def task() -> None:
+        """Task endpoint."""
+
+    delayer = cast(Delayer, task.options(callback_base_url="https://override.example/tasks"))
+
+    assert delayer.base_url == "https://override.example/tasks"
+
+
+def test_delayed_task_rejects_conflicting_per_call_callback_names() -> None:
+    """Per-call options should reject the preferred name combined with its alias."""
+    client = MagicMock(spec=tasks_v2.CloudTasksClient)
+    route_class = DelayedRouteBuilder(
+        callback_base_url="https://default.example/tasks",
+        queue_path=QUEUE_PATH,
+        client=client,
+        auto_create_queue=False,
+    )
+    router = APIRouter(route_class=route_class)
+
+    @router.post("/task")
+    @as_delayed_task
+    def task() -> None:
+        """Task endpoint."""
+
+    with pytest.raises(TypeError, match="not both"):
+        task.options(
+            callback_base_url="https://preferred.example/tasks",
+            base_url="https://legacy.example/tasks",
+        )

--- a/tests/test_duplicate_endpoints.py
+++ b/tests/test_duplicate_endpoints.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 # Third Party Imports
 import pytest
-from fastapi import APIRouter
+from fastapi import APIRouter, FastAPI
 from fastapi.routing import APIRoute
 from google.cloud import scheduler_v1, tasks_v2
 
@@ -78,6 +78,96 @@ def test_endpoint_cannot_be_registered_on_two_task_paths(route_class_factory: Ro
 
     with pytest.raises(ValueError, match=r"already registered.*?/first.*?/second"):
         router.add_api_route("/second", task, methods=["POST"])
+
+
+@pytest.mark.parametrize(
+    "route_class_factory",
+    [
+        _delayed_route_class,
+        _async_delayed_route_class,
+        _scheduled_route_class,
+        _async_scheduled_route_class,
+    ],
+)
+def test_endpoint_cannot_be_registered_twice_at_same_path(route_class_factory: RouteClassFactory) -> None:
+    """Equal paths with different methods are distinct, ambiguous task operations."""
+    router = APIRouter(route_class=route_class_factory())
+
+    def task() -> None:
+        """Task endpoint."""
+
+    router.add_api_route("/task", task, methods=["GET"])
+
+    with pytest.raises(ValueError, match=r"already registered.*?/task"):
+        router.add_api_route("/task", task, methods=["POST"])
+
+
+@pytest.mark.parametrize(
+    "route_class_factory",
+    [
+        _delayed_route_class,
+        _async_delayed_route_class,
+        _scheduled_route_class,
+        _async_scheduled_route_class,
+    ],
+)
+def test_endpoint_cannot_be_registered_on_suffix_path(route_class_factory: RouteClassFactory) -> None:
+    """A suffix match alone does not make a direct registration an inclusion clone."""
+    router = APIRouter(route_class=route_class_factory())
+
+    def task() -> None:
+        """Task endpoint."""
+
+    router.add_api_route("/task", task, methods=["POST"])
+
+    with pytest.raises(ValueError, match=r"already registered.*?/task.*?/outer/task"):
+        router.add_api_route("/outer/task", task, methods=["POST"])
+
+
+@pytest.mark.parametrize(
+    "route_class_factory",
+    [
+        _delayed_route_class,
+        _async_delayed_route_class,
+        _scheduled_route_class,
+        _async_scheduled_route_class,
+    ],
+)
+def test_old_style_router_inclusion_can_reuse_endpoint_binding(route_class_factory: RouteClassFactory) -> None:
+    """A real inclusion clone may retain the original route's task helper."""
+    task_router = APIRouter(route_class=route_class_factory())
+
+    def task() -> None:
+        """Task endpoint."""
+
+    task_router.add_api_route("/task", task, methods=["POST"])
+
+    outer_router = APIRouter()
+    outer_router.include_router(task_router, prefix="/outer")
+
+
+def test_old_style_router_inclusion_preserves_custom_operation_ids() -> None:
+    """The clone marker must delegate to the configured operation ID generator."""
+
+    def custom_operation_id(route: APIRoute) -> str:
+        return f"custom{route.path.replace('/', '_')}"
+
+    task_router = APIRouter(
+        route_class=_delayed_route_class(),
+        generate_unique_id_function=custom_operation_id,
+    )
+
+    def task() -> None:
+        """Task endpoint."""
+
+    task_router.add_api_route("/task", task, methods=["POST"])
+    outer_router = APIRouter()
+    outer_router.include_router(task_router, prefix="/outer")
+    app = FastAPI()
+    app.include_router(outer_router)
+
+    operation = app.openapi()["paths"]["/outer/task"]["post"]
+    assert operation["operationId"] == "custom_outer_task"
 
 
 def test_endpoint_cannot_be_registered_by_two_delayed_route_builders() -> None:

--- a/tests/test_duplicate_endpoints.py
+++ b/tests/test_duplicate_endpoints.py
@@ -1,0 +1,94 @@
+"""Regression tests for endpoints registered on more than one task path."""
+
+# Standard Library Imports
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+# Third Party Imports
+import pytest
+from fastapi import APIRouter
+from fastapi.routing import APIRoute
+from google.cloud import scheduler_v1, tasks_v2
+
+# Imports from this repository
+from fastapi_gcp_tasks import (
+    AsyncDelayedRouteBuilder,
+    AsyncScheduledRouteBuilder,
+    DelayedRouteBuilder,
+    ScheduledRouteBuilder,
+)
+
+QUEUE_PATH = "projects/test-project/locations/us-central1/queues/test-queue"
+LOCATION_PATH = "projects/test-project/locations/us-central1"
+CALLBACK_BASE_URL = "https://worker.example.com/tasks"
+
+RouteClassFactory = Callable[[], type[APIRoute]]
+
+
+def _delayed_route_class() -> type[APIRoute]:
+    return DelayedRouteBuilder(
+        callback_base_url=CALLBACK_BASE_URL,
+        queue_path=QUEUE_PATH,
+        client=MagicMock(spec=tasks_v2.CloudTasksClient),
+        auto_create_queue=False,
+    )
+
+
+def _async_delayed_route_class() -> type[APIRoute]:
+    return AsyncDelayedRouteBuilder(
+        callback_base_url=CALLBACK_BASE_URL,
+        queue_path=QUEUE_PATH,
+        client=MagicMock(spec=tasks_v2.CloudTasksAsyncClient),
+    )
+
+
+def _scheduled_route_class() -> type[APIRoute]:
+    return ScheduledRouteBuilder(
+        callback_base_url=CALLBACK_BASE_URL,
+        location_path=LOCATION_PATH,
+        client=MagicMock(spec=scheduler_v1.CloudSchedulerClient),
+    )
+
+
+def _async_scheduled_route_class() -> type[APIRoute]:
+    return AsyncScheduledRouteBuilder(
+        callback_base_url=CALLBACK_BASE_URL,
+        location_path=LOCATION_PATH,
+        client=MagicMock(spec=scheduler_v1.CloudSchedulerAsyncClient),
+    )
+
+
+@pytest.mark.parametrize(
+    "route_class_factory",
+    [
+        _delayed_route_class,
+        _async_delayed_route_class,
+        _scheduled_route_class,
+        _async_scheduled_route_class,
+    ],
+)
+def test_endpoint_cannot_be_registered_on_two_task_paths(route_class_factory: RouteClassFactory) -> None:
+    """One function-level task helper cannot unambiguously represent two callback paths."""
+    router = APIRouter(route_class=route_class_factory())
+
+    def task() -> None:
+        """Task endpoint."""
+
+    router.add_api_route("/first", task, methods=["POST"])
+
+    with pytest.raises(ValueError, match=r"already registered.*?/first.*?/second"):
+        router.add_api_route("/second", task, methods=["POST"])
+
+
+def test_endpoint_cannot_be_registered_by_two_delayed_route_builders() -> None:
+    """Separate builder instances must not silently overwrite the same endpoint's helper."""
+    first_router = APIRouter(route_class=_delayed_route_class())
+    second_router = APIRouter(route_class=_delayed_route_class())
+
+    def task() -> None:
+        """Task endpoint."""
+
+    first_router.add_api_route("/first", task, methods=["POST"])
+
+    with pytest.raises(ValueError, match=r"already registered.*?/first.*?/second"):
+        second_router.add_api_route("/second", task, methods=["POST"])

--- a/tests/test_router_prefixes.py
+++ b/tests/test_router_prefixes.py
@@ -1,0 +1,127 @@
+"""Regression tests for callback URLs when task routers are included under an outer prefix."""
+
+# Standard Library Imports
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+# Third Party Imports
+from fastapi import APIRouter, FastAPI
+from google.cloud import scheduler_v1, tasks_v2
+
+# Imports from this repository
+from fastapi_gcp_tasks import (
+    AsyncDelayedRouteBuilder,
+    AsyncScheduledRouteBuilder,
+    DelayedRouteBuilder,
+    ScheduledRouteBuilder,
+    as_async_delayed_task,
+    as_async_scheduled_task,
+    as_delayed_task,
+    as_scheduled_task,
+)
+from fastapi_gcp_tasks.async_scheduler import AsyncScheduler
+from fastapi_gcp_tasks.scheduler import Scheduler
+
+ORIGIN = "https://worker.example.com"
+CALLBACK_BASE_URL = f"{ORIGIN}/tasks"
+QUEUE_PATH = "projects/test-project/locations/us-central1/queues/test-queue"
+LOCATION_PATH = "projects/test-project/locations/us-central1"
+
+
+def test_delayed_route_uses_explicit_callback_base_for_outer_router_prefix() -> None:
+    """A sync delayed task should target the same externally mounted path FastAPI serves."""
+    client = MagicMock(spec=tasks_v2.CloudTasksClient)
+    client.create_task.return_value = tasks_v2.Task()
+    route_class = cast(Any, DelayedRouteBuilder)(
+        callback_base_url=CALLBACK_BASE_URL,
+        queue_path=QUEUE_PATH,
+        client=client,
+        auto_create_queue=False,
+    )
+    task_router = APIRouter(route_class=route_class, prefix="/auth")
+
+    @task_router.post("/confirm/{user_id}")
+    @as_delayed_task
+    def confirm_user(user_id: str) -> None:
+        """Confirm a user."""
+
+    app = FastAPI()
+    app.include_router(task_router, prefix="/tasks")
+
+    confirm_user.delay(user_id="42")
+
+    request = client.create_task.call_args.kwargs["request"]
+    assert request.task.http_request.url == f"{ORIGIN}{app.url_path_for('confirm_user', user_id='42')}"
+
+
+async def test_async_delayed_route_uses_explicit_callback_base_for_outer_router_prefix() -> None:
+    """An async delayed task should target the same externally mounted path FastAPI serves."""
+    client = MagicMock(spec=tasks_v2.CloudTasksAsyncClient)
+    client.create_task = AsyncMock(return_value=tasks_v2.Task())
+    route_class = cast(Any, AsyncDelayedRouteBuilder)(
+        callback_base_url=CALLBACK_BASE_URL,
+        queue_path=QUEUE_PATH,
+        client=client,
+    )
+    task_router = APIRouter(route_class=route_class, prefix="/auth")
+
+    @task_router.post("/confirm/{user_id}")
+    @as_async_delayed_task
+    async def confirm_user(user_id: str) -> None:
+        """Confirm a user."""
+
+    app = FastAPI()
+    app.include_router(task_router, prefix="/tasks")
+
+    await confirm_user.delay(user_id="42")
+
+    request = client.create_task.await_args.kwargs["request"]
+    assert request.task.http_request.url == f"{ORIGIN}{app.url_path_for('confirm_user', user_id='42')}"
+
+
+def test_scheduled_route_uses_explicit_callback_base_for_outer_router_prefix() -> None:
+    """A sync scheduled job should target the same externally mounted path FastAPI serves."""
+    client = MagicMock(spec=scheduler_v1.CloudSchedulerClient)
+    route_class = cast(Any, ScheduledRouteBuilder)(
+        callback_base_url=CALLBACK_BASE_URL,
+        location_path=LOCATION_PATH,
+        client=client,
+    )
+    job_router = APIRouter(route_class=route_class, prefix="/maintenance")
+
+    @job_router.post("/sweep")
+    @as_scheduled_task
+    def sweep() -> None:
+        """Run periodic maintenance."""
+
+    app = FastAPI()
+    app.include_router(job_router, prefix="/tasks")
+
+    scheduler = cast(Scheduler, sweep.scheduler(name="sweep", schedule="0 * * * *"))
+    request = scheduler._build_create_job_request(values={})
+
+    assert request.job.http_target.uri == f"{ORIGIN}{app.url_path_for('sweep')}"
+
+
+def test_async_scheduled_route_uses_explicit_callback_base_for_outer_router_prefix() -> None:
+    """An async scheduled job should target the same externally mounted path FastAPI serves."""
+    client = MagicMock(spec=scheduler_v1.CloudSchedulerAsyncClient)
+    route_class = cast(Any, AsyncScheduledRouteBuilder)(
+        callback_base_url=CALLBACK_BASE_URL,
+        location_path=LOCATION_PATH,
+        client=client,
+    )
+    job_router = APIRouter(route_class=route_class, prefix="/maintenance")
+
+    @job_router.post("/sweep")
+    @as_async_scheduled_task
+    async def sweep() -> None:
+        """Run periodic maintenance."""
+
+    app = FastAPI()
+    app.include_router(job_router, prefix="/tasks")
+
+    scheduler = cast(AsyncScheduler, sweep.scheduler(name="sweep", schedule="0 * * * *"))
+    request = scheduler._build_create_job_request(values={})
+
+    assert request.job.http_target.uri == f"{ORIGIN}{app.url_path_for('sweep')}"

--- a/uv.lock
+++ b/uv.lock
@@ -348,7 +348,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.139.0"
+version = "0.139.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -357,9 +357,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/95/d3f0ae10836324a2eab98a52b61210ac609f08200bf4bb0dc8132d32f78a/fastapi-0.139.2.tar.gz", hash = "sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e", size = 423428, upload-time = "2026-07-16T15:06:17.912Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c7/cb03251d9dfb177246a9809a76f189d21df32dbd4a845951881d11323b7f/fastapi-0.139.2-py3-none-any.whl", hash = "sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c", size = 130234, upload-time = "2026-07-16T15:06:19.557Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add `callback_base_url` as the explicit, preferred callback prefix for delayed and scheduled routes while retaining `base_url` as a backward-compatible alias
- bind endpoint helpers during route construction instead of using `get_route_handler()` as a lifecycle side effect
- keep bindings stable across FastAPI's pre-0.137 cloned routes and 0.137+ preserved router trees
- document outer `include_router()` prefixes and the distinction between callback URLs and OIDC audiences
- update the lockfile from FastAPI 0.139.0 to 0.139.2

## Why

FastAPI 0.137 stopped cloning routes when routers are included. A task route now retains its locally declared path and cannot see a prefix added later by an outer `include_router()` call. As a result, callback URLs can silently omit prefixes such as `/tasks` and return 404 in production.

The library also cannot infer the correct effective path in general because the same router may be included more than once. This change makes the externally reachable callback prefix explicit and keeps route objects internally consistent.

## Verification

- `make test` — 52 passed against locked FastAPI 0.139.2
- `make lint` — strict mypy, Ruff lint, and format checks passed
- `make docs-build` — strict MkDocs build passed
- `uv run --with fastapi==0.110.0 pytest -q tests/test_router_prefixes.py tests/test_typed_api.py` — 13 passed against the minimum supported FastAPI version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing outer router prefixes in task callback URLs with nested routers on FastAPI 0.137+, preventing 404s. Adds explicit `callback_base_url` (keeps `base_url` as legacy), documents nested scheduled routes, and bumps `fastapi` to 0.139.2.

- **Migration**
  - Use callback_base_url instead of base_url; pass only one.
  - Include any outer include_router() prefix in callback_base_url.
  - Per-call overrides supported via options(callback_base_url=...).
  - OIDC audience should remain the service origin (no callback path).

- **Bug Fixes**
  - Reject duplicate endpoint registrations across paths or builders; allow only actual FastAPI inclusion clones (pre-0.137) to reuse the helper and reject lookalikes (suffix paths or same path with different methods) with clear errors.

<sup>Written for commit ca170db20a08a1a8826128d34eaea3edc350dbbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SimplifyJobs/fastapi-gcp-tasks/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

