### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi-gcp-tasks"
-version = "0.2.0"
+version = "0.3.0"
 description = "Trigger delayed Cloud Tasks from FastAPI"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-gcp-tasks"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- bump fastapi-gcp-tasks from 0.2.0 to 0.3.0
- update the locked editable package version
- prepare the release containing support for FastAPI's router-preserving include_router approach

## Verification

- 70 tests passed
- strict mypy, Ruff, and formatting checks passed
- strict documentation build passed
- source distribution and wheel built successfully
- built wheel installed and imported successfully in an isolated environment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `fastapi-gcp-tasks` to 0.3.0 to publish support for `FastAPI`’s router-preserving include_router pattern. Updates versions in pyproject.toml and uv.lock for the release.

<sup>Written for commit ecdbf1f72657d17347c82f09124dbf1a8a5044d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SimplifyJobs/fastapi-gcp-tasks/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

